### PR TITLE
fix: silent error when createHandler throws an error and app.init fails

### DIFF
--- a/.changeset/little-moons-matter.md
+++ b/.changeset/little-moons-matter.md
@@ -2,4 +2,4 @@
 "@vercel/slack-bolt": patch
 ---
 
-Fix empty error log for when createHandler fails. We incorrectly used the app.logger which was not available if app.init failed.
+Bug fix for empty error log when `createHandler` fails. Use `console.error` instead of `app.logger.error` which is undefined if `app.init` fails.

--- a/.changeset/little-moons-matter.md
+++ b/.changeset/little-moons-matter.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": patch
+---
+
+Fix empty error log for when createHandler fails. We incorrectly used the app.logger which was not available if app.init failed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,8 +465,7 @@ export function createHandler(
       const handler = await receiver.start();
       return handler(req);
     } catch (error) {
-      const logger = receiver.getLogger();
-      logger.error(ERROR_MESSAGES.CREATE_HANDLER_ERROR, error);
+      console.error(ERROR_MESSAGES.CREATE_HANDLER_ERROR, error);
       return new Response(
         JSON.stringify({
           error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR_HANDLER,

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,6 +465,7 @@ export function createHandler(
       const handler = await receiver.start();
       return handler(req);
     } catch (error) {
+      // if app.init fails, we use console.error instead of logger.error because the logger is not available
       console.error(ERROR_MESSAGES.CREATE_HANDLER_ERROR, error);
       return new Response(
         JSON.stringify({


### PR DESCRIPTION
Fixes a bug when `createHandler` throws an error and app.init fails. This caused `app.logger` to be `undefined` so no error logs are seen in the terminal.