### PR TITLE
add dependabot and auto-changeset workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+  # Root devDependencies (turbo, biome, husky)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      root-dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "malewis5"
+
+  # Published package (@vercel/slack-bolt)
+  - package-ecosystem: "npm"
+    directory: "/packages/slack-bolt"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      package-dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      package-production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "malewis5"
+
+  # Example app (nextjs)
+  - package-ecosystem: "npm"
+    directory: "/examples/nextjs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      example-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "malewis5"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "malewis5"

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -1,0 +1,76 @@
+name: Dependabot Changeset
+
+on:
+  pull_request:
+    paths:
+      - "packages/slack-bolt/package.json"
+
+permissions:
+  contents: write
+
+jobs:
+  changeset:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if published deps changed
+        id: check
+        run: |
+          BASE_DEPS=$(git show origin/master:packages/slack-bolt/package.json | node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+            console.log(JSON.stringify({
+              deps: pkg.dependencies || {},
+              peer: pkg.peerDependencies || {}
+            }));
+          ")
+          HEAD_DEPS=$(node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('packages/slack-bolt/package.json','utf8'));
+            console.log(JSON.stringify({
+              deps: pkg.dependencies || {},
+              peer: pkg.peerDependencies || {}
+            }));
+          ")
+
+          if [ "$BASE_DEPS" != "$HEAD_DEPS" ]; then
+            echo "needs_changeset=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_changeset=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate changeset
+        if: steps.check.outputs.needs_changeset == 'true'
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          CHANGESET_ID=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
+
+          if [ -f ".changeset/${CHANGESET_ID}.md" ]; then
+            echo "Changeset already exists, skipping."
+            exit 0
+          fi
+
+          cat > ".changeset/${CHANGESET_ID}.md" <<'EOF'
+          ---
+          "@vercel/slack-bolt": patch
+          ---
+
+          bump deps
+          EOF
+
+          sed -i 's/^          //' ".changeset/${CHANGESET_ID}.md"
+
+      - name: Commit changeset
+        if: steps.check.outputs.needs_changeset == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .changeset/
+          git diff --cached --quiet && exit 0
+          git commit -m "add changeset for dependency update"
+          git push


### PR DESCRIPTION
## Summary
- Adds Dependabot config with separate update schedules for the published package (`packages/slack-bolt`), example app (`examples/nextjs`), root devDependencies, and GitHub Actions
- Adds a companion workflow that auto-generates a patch changeset when Dependabot bumps production or peer deps in `@vercel/slack-bolt`, so the release pipeline stays intact
- Minor/patch updates are grouped to reduce PR noise; major bumps come as individual PRs for manual review

## Test plan
- [ ] Verify Dependabot starts opening PRs after merge (next Monday cycle)
- [ ] Confirm changeset workflow triggers on package dep PRs and skips devDependency-only PRs
- [ ] Confirm CI runs on Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)