### PR TITLE
ci: add attw type export validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,6 @@ jobs:
 
       - name: Build
         run: pnpm exec turbo run build
+
+      - name: Check exported types
+        run: pnpm exec turbo run attw

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,8 @@
     "lint": {},
     "lint:fix": {},
     "test": {},
-    "attw": {}
+    "attw": {
+      "dependsOn": ["build"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `attw` (Are The Types Wrong) to the CI pipeline after build
- Validates that the package's `exports` map and type declarations resolve correctly across all module resolution strategies (node10, node16 CJS/ESM, bundler)
- Adds `dependsOn: ["build"]` to the `attw` turbo task so it runs after the package is built

## Why
A bad `exports` or `typesVersions` change could ship types that don't resolve for consumers. `attw` catches this before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)