### PR TITLE
chore: limit dependabot to 1 PR per directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,7 @@ updates:
     groups:
       root-dev-dependencies:
         dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     reviewers:
       - "malewis5"
 
@@ -23,17 +20,10 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
-      package-dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      package-production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 10
+      all-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
     reviewers:
       - "malewis5"
 
@@ -45,10 +35,9 @@ updates:
       day: "monday"
     groups:
       example-dependencies:
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
     reviewers:
       - "malewis5"
 
@@ -58,6 +47,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
     reviewers:
       - "malewis5"


### PR DESCRIPTION
## Summary
- Set `open-pull-requests-limit: 1` on all 4 ecosystem entries (was 5-10)
- Use wildcard `patterns: ["*"]` to group all update types (major, minor, patch) into a single PR per directory
- Consolidate `/packages/slack-bolt` from two separate groups (dev + production) into one `all-dependencies` group
- Add `all-actions` group for GitHub Actions entry

Max PRs per week drops from 25 to 4 (one per directory/ecosystem entry).

## Test plan
- [ ] Verify Dependabot opens grouped PRs on next Monday run
- [ ] Confirm no more than 1 PR per ecosystem entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)