### PR TITLE
[slack-bolt] adding dynamic scope resolution + pre-processing hooks

### DIFF
--- a/.changeset/olive-news-beam.md
+++ b/.changeset/olive-news-beam.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": minor
+---
+
+Adding before process function + dynamic scope resolution

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -1,7 +1,7 @@
 # @vercel/slack-bolt
 
-[![npm version](https://img.shields.io/npm/v/%40vercel%2Fslack-bolt)](https://www.npmjs.com/package/@vercel/slack-bolt)
-[![npm downloads](https://img.shields.io/npm/dm/%40vercel%2Fslack-bolt?label=downloads)](https://www.npmjs.com/package/@vercel/slack-bolt)
+[npm version](https://www.npmjs.com/package/@vercel/slack-bolt)
+[npm downloads](https://www.npmjs.com/package/@vercel/slack-bolt)
 
 A custom [Slack Bolt](https://slack.dev/bolt-js/) receiver built for Vercel's [Fluid Compute](https://vercel.com/docs/fluid-compute).
 
@@ -51,29 +51,32 @@ export { app, receiver };
 
 #### Parameters
 
-| Name                        | Type                              | Default Value                        | Required       | Description                                                            |
-| --------------------------- | --------------------------------- | ------------------------------------ | -------------- | ---------------------------------------------------------------------- |
-| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET`   | No<sup>1</sup> | Signing secret for your Slack app used to verify requests.             |
-| `signatureVerification`     | `boolean`                         | `true`                               | No             | Enable or disable request signature verification.                      |
-| `logger`                    | `Logger`<sup>2</sup>              | `new ConsoleLogger()`                | No             | Logger used for diagnostics.                                           |
-| `logLevel`                  | `LogLevel`<sup>2</sup>            | `LogLevel.INFO`                      | No             | Minimum log level for the logger.                                      |
-| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                          | No             | Return value is merged into Bolt event `customProperties`<sup>2</sup>. |
-| `ackTimeoutMs`              | `number`                          | `3001`                               | No             | Milliseconds to wait for `ack()` before returning a timeout error.     |
-| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`        | No<sup>3</sup> | Your app's client ID (required for OAuth).                             |
-| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`    | No<sup>3</sup> | Your app's client secret (required for OAuth).                         |
-| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`     | No<sup>3</sup> | Secret for OAuth CSRF state parameter.                                 |
-| `scopes`                    | `string[]`                        | `undefined`                          | No             | Bot scopes to request during the OAuth flow.                           |
-| `redirectUri`               | `string`                          | `undefined`                          | No             | Redirect URI registered with your Slack app.                           |
-| `installationStore`         | `InstallationStore`<sup>2</sup>   | `undefined`                          | No<sup>4</sup> | Persistent storage backend for OAuth installations.                    |
-| `installerOptions`          | `VercelInstallerOptions`          | `{}`                                 | No             | Advanced OAuth options (user scopes, direct install, state store, etc). |
 
-<sup>1</sup> Optional if `process.env.SLACK_SIGNING_SECRET` is provided.
+| Name                        | Type                              | Default Value                      | Required | Description                                                               |
+| --------------------------- | --------------------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET` | No1      | Signing secret for your Slack app used to verify requests.                |
+| `signatureVerification`     | `boolean`                         | `true`                             | No       | Enable or disable request signature verification.                         |
+| `logger`                    | `Logger`2                         | `new ConsoleLogger()`              | No       | Logger used for diagnostics.                                              |
+| `logLevel`                  | `LogLevel`2                       | `LogLevel.INFO`                    | No       | Minimum log level for the logger.                                         |
+| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No       | Return value is merged into Bolt event `customProperties`2.               |
+| `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No       | Intercept requests before Bolt processing.                                |
+| `ackTimeoutMs`              | `number`                          | `3001`                             | No       | Milliseconds to wait for `ack()` before returning a timeout error.        |
+| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No3      | Your app's client ID (required for OAuth).                                |
+| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`  | No3      | Your app's client secret (required for OAuth).                            |
+| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`   | No3      | Secret for OAuth CSRF state parameter.                                    |
+| `scopes`                    | `string[] | ScopesResolver`       | `undefined`                        | No       | Bot scopes to request during OAuth. Can be a function for dynamic scopes. |
+| `redirectUri`               | `string`                          | `undefined`                        | No       | Redirect URI registered with your Slack app.                              |
+| `installationStore`         | `InstallationStore`2              | `undefined`                        | No4      | Persistent storage backend for OAuth installations.                       |
+| `installerOptions`          | `VercelInstallerOptions`          | `{}`                               | No       | Advanced OAuth options (user scopes, direct install, state store, etc).   |
 
-<sup>2</sup> Provided by the [`@slack/bolt`](https://www.npmjs.com/package/@slack/bolt) library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
 
-<sup>3</sup> Required for OAuth. Read from `process.env` automatically if not provided.
+1 Optional if `process.env.SLACK_SIGNING_SECRET` is provided.
 
-<sup>4</sup> Required for OAuth in serverless environments -- the default in-memory store does not persist across cold starts.
+2 Provided by the `[@slack/bolt](https://www.npmjs.com/package/@slack/bolt)` library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
+
+3 Required for OAuth. Read from `process.env` automatically if not provided.
+
+4 Required for OAuth in serverless environments -- the default in-memory store does not persist across cold starts.
 
 ### `createHandler`
 
@@ -90,12 +93,14 @@ export const POST = createHandler(app, receiver);
 
 #### Parameters
 
-| Name       | Type              | Required | Description                                                  |
-| ---------- | ----------------- | -------- | ------------------------------------------------------------ |
-| `app`      | `App`<sup>1</sup> | Yes      | Your Bolt app                                                |
-| `receiver` | `VercelReceiver`  | Yes      | The Vercel receiver instance used to process Slack requests. |
 
-<sup>1</sup> Provided by the [`@slack/bolt`](https://www.npmjs.com/package/@slack/bolt) library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
+| Name       | Type             | Required | Description                                                  |
+| ---------- | ---------------- | -------- | ------------------------------------------------------------ |
+| `app`      | `App`1           | Yes      | Your Bolt app                                                |
+| `receiver` | `VercelReceiver` | Yes      | The Vercel receiver instance used to process Slack requests. |
+
+
+1 Provided by the `[@slack/bolt](https://www.npmjs.com/package/@slack/bolt)` library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
 
 ## OAuth (Multi-Tenant Apps)
 
@@ -105,12 +110,14 @@ export const POST = createHandler(app, receiver);
 
 Set these in your Vercel project (or `.env.local` for local development):
 
-| Variable              | Description                                              |
-| --------------------- | -------------------------------------------------------- |
-| `SLACK_CLIENT_ID`     | App client ID, found under **Basic Information** on [api.slack.com](https://api.slack.com/apps). |
-| `SLACK_CLIENT_SECRET` | App client secret, found in the same section.            |
-| `SLACK_STATE_SECRET`  | A random string used to sign the OAuth state parameter.  |
-| `SLACK_SIGNING_SECRET`| Signing secret for verifying incoming Slack requests.    |
+
+| Variable               | Description                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| `SLACK_CLIENT_ID`      | App client ID, found under **Basic Information** on [api.slack.com](https://api.slack.com/apps). |
+| `SLACK_CLIENT_SECRET`  | App client secret, found in the same section.                                                    |
+| `SLACK_STATE_SECRET`   | A random string used to sign the OAuth state parameter.                                          |
+| `SLACK_SIGNING_SECRET` | Signing secret for verifying incoming Slack requests.                                            |
+
 
 All four are read from `process.env` automatically.
 
@@ -179,31 +186,35 @@ const result = await preview({
 
 #### Parameters (`PreviewParams`)
 
-| Name                      | Type     | Required | Description                                                        |
-| ------------------------- | -------- | -------- | ------------------------------------------------------------------ |
-| `branch`                  | `string` | Yes      | Git branch name for the preview deployment.                        |
-| `projectId`               | `string` | Yes      | Vercel project ID.                                                 |
-| `deploymentUrl`           | `string` | Yes      | URL of the current deployment.                                     |
-| `manifestPath`            | `string` | Yes      | Path to the Slack app `manifest.json` file.                        |
-| `slackConfigurationToken` | `string` | Yes      | Slack app configuration token.                                     |
-| `vercelApiToken`          | `string` | Yes      | Vercel API token with write access.                                |
-| `branchUrl`               | `string` | No       | Branch-specific URL. Defaults to `deploymentUrl`.                  |
-| `slackAppId`              | `string` | No       | Existing Slack app ID to update instead of creating a new one.     |
-| `slackServiceToken`       | `string` | No       | Service token for auto-installing the app.                         |
-| `teamId`                  | `string` | No       | Vercel team ID.                                                    |
-| `deploymentId`            | `string` | No       | Current deployment ID (used for cancel-and-redeploy).              |
-| `automationBypassSecret`  | `string` | No       | Existing bypass secret. Generated automatically if not provided.   |
-| `commitSha`               | `string` | No       | Git commit SHA (displayed in the Slack app description).           |
-| `commitMessage`           | `string` | No       | Git commit message (displayed in the Slack app description).       |
-| `commitAuthor`            | `string` | No       | Git commit author (displayed in the Slack app description).        |
+
+| Name                      | Type     | Required | Description                                                      |
+| ------------------------- | -------- | -------- | ---------------------------------------------------------------- |
+| `branch`                  | `string` | Yes      | Git branch name for the preview deployment.                      |
+| `projectId`               | `string` | Yes      | Vercel project ID.                                               |
+| `deploymentUrl`           | `string` | Yes      | URL of the current deployment.                                   |
+| `manifestPath`            | `string` | Yes      | Path to the Slack app `manifest.json` file.                      |
+| `slackConfigurationToken` | `string` | Yes      | Slack app configuration token.                                   |
+| `vercelApiToken`          | `string` | Yes      | Vercel API token with write access.                              |
+| `branchUrl`               | `string` | No       | Branch-specific URL. Defaults to `deploymentUrl`.                |
+| `slackAppId`              | `string` | No       | Existing Slack app ID to update instead of creating a new one.   |
+| `slackServiceToken`       | `string` | No       | Service token for auto-installing the app.                       |
+| `teamId`                  | `string` | No       | Vercel team ID.                                                  |
+| `deploymentId`            | `string` | No       | Current deployment ID (used for cancel-and-redeploy).            |
+| `automationBypassSecret`  | `string` | No       | Existing bypass secret. Generated automatically if not provided. |
+| `commitSha`               | `string` | No       | Git commit SHA (displayed in the Slack app description).         |
+| `commitMessage`           | `string` | No       | Git commit message (displayed in the Slack app description).     |
+| `commitAuthor`            | `string` | No       | Git commit author (displayed in the Slack app description).      |
+
 
 #### Return value (`PreviewResult`)
 
-| Name            | Type      | Description                                                   |
-| --------------- | --------- | ------------------------------------------------------------- |
-| `isNew`         | `boolean` | `true` if a new Slack app was created, `false` if updated.    |
+
+| Name            | Type      | Description                                                       |
+| --------------- | --------- | ----------------------------------------------------------------- |
+| `isNew`         | `boolean` | `true` if a new Slack app was created, `false` if updated.        |
 | `installStatus` | `string`  | Installation outcome (e.g. `installed`, `missing_service_token`). |
-| `app`           | `object`  | Slack API response containing `app_id` and credentials.       |
+| `app`           | `object`  | Slack API response containing `app_id` and credentials.           |
+
 
 ## Preview Deployments
 
@@ -252,12 +263,14 @@ Place a [Slack app manifest](https://api.slack.com/reference/manifests) in your 
 
 Add the following to your Vercel project:
 
-| Variable                      | Required | Description                                                                                                                                            |
-| ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SLACK_CONFIGURATION_TOKEN`   | Yes      | App configuration token. Generate at https://api.slack.com/apps. Expires after 12 hours.                                                               |
-| `SLACK_CONFIG_REFRESH_TOKEN`  | No       | Refresh token for automatic rotation of expired configuration tokens. Provided alongside the configuration token. Strongly recommended.                 |
-| `VERCEL_API_TOKEN`            | Yes      | Vercel API token with write access. Create at https://vercel.com/account/settings/tokens                                                               |
-| `SLACK_SERVICE_TOKEN`         | No       | Service token for auto-installing the app. Without this, the app must be installed manually. See https://docs.slack.dev/authentication/tokens/#service |
+
+| Variable                     | Required | Description                                                                                                                                                                                                     |
+| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SLACK_CONFIGURATION_TOKEN`  | Yes      | App configuration token. Generate at [https://api.slack.com/apps](https://api.slack.com/apps). Expires after 12 hours.                                                                                          |
+| `SLACK_CONFIG_REFRESH_TOKEN` | No       | Refresh token for automatic rotation of expired configuration tokens. Provided alongside the configuration token. Strongly recommended.                                                                         |
+| `VERCEL_API_TOKEN`           | Yes      | Vercel API token with write access. Create at [https://vercel.com/account/settings/tokens](https://vercel.com/account/settings/tokens)                                                                          |
+| `SLACK_SERVICE_TOKEN`        | No       | Service token for auto-installing the app. Without this, the app must be installed manually. See [https://docs.slack.dev/authentication/tokens/#service](https://docs.slack.dev/authentication/tokens/#service) |
+
 
 You must also enable **Automatically expose System Environment Variables** in your Vercel project settings.
 
@@ -299,6 +312,62 @@ Options:
 
 All Vercel and Slack environment variables are read automatically. You can override any of them via CLI flags (e.g. `--vercel-env`, `--slack-app-id`).
 
+## Advanced
+
+### Request Interception
+
+The `beforeProcess` hook lets you intercept requests after signature verification but before Bolt processes them. Return a `Response` to short-circuit processing, or `undefined` to continue normally.
+
+This is useful for:
+
+- Routing certain workspaces to different backends
+- Custom logging or metrics
+- Early rejection based on request content
+
+```typescript
+const receiver = new VercelReceiver({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  beforeProcess: async (req, body) => {
+    // Forward enterprise workspaces to a dedicated service
+    if (body.team_id === 'T_ENTERPRISE') {
+      return fetch('https://enterprise-handler.example.com/slack', {
+        method: 'POST',
+        body: await req.text(),
+        headers: req.headers,
+      });
+    }
+    // Return undefined to continue normal Bolt processing
+  },
+});
+```
+
+> **Note:** `beforeProcess` is not called for `url_verification` challenge requests, which are handled automatically.
+
+### Dynamic Scopes
+
+The `scopes` option accepts either a static array or a resolver function. This enables requesting different OAuth scopes based on the install request context (e.g., different scopes for enterprise vs. standard workspaces).
+
+```typescript
+const receiver = new VercelReceiver({
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: process.env.SLACK_STATE_SECRET,
+  installationStore: myInstallationStore,
+  scopes: async (req) => {
+    const url = new URL(req.url);
+    const isEnterprise = url.searchParams.get('enterprise') === 'true';
+    
+    const baseScopes = ['chat:write', 'commands'];
+    if (isEnterprise) {
+      return [...baseScopes, 'users:read', 'channels:read'];
+    }
+    return baseScopes;
+  },
+});
+```
+
+The resolver receives the install request, allowing you to inspect query parameters, headers, or any other request data to determine which scopes to request.
+
 ## Examples
 
 Starter templates: [Next.js](https://github.com/vercel-labs/slack-bolt/tree/examples/examples/nextjs), [Hono](https://github.com/vercel-labs/slack-bolt/tree/examples/examples/hono), [Nitro](https://github.com/vercel-labs/slack-bolt/tree/examples/examples/nitro).
@@ -314,3 +383,4 @@ For issues and questions:
 - Check the [Slack Bolt documentation](https://slack.dev/bolt-js/)
 - Review [Vercel Functions documentation](https://vercel.com/docs/functions)
 - [Open an issue](https://github.com/vercel-labs/slack-bolt/issues) in this repository
+

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -51,30 +51,30 @@ export { app, receiver };
 
 #### Parameters
 
-| Name                        | Type                              | Default Value                      | Required    | Description                                                             |
-| --------------------------- | --------------------------------- | ---------------------------------- | ----------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET` | No1         | Signing secret for your Slack app used to verify requests.              |
-| `signatureVerification`     | `boolean`                         | `true`                             | No          | Enable or disable request signature verification.                       |
-| `logger`                    | `Logger`2                         | `new ConsoleLogger()`              | No          | Logger used for diagnostics.                                            |
-| `logLevel`                  | `LogLevel`2                       | `LogLevel.INFO`                    | No          | Minimum log level for the logger.                                       |
-| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No          | Return value is merged into Bolt event `customProperties`2.             |
-| `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No          | Intercept requests before Bolt processing.                              |
-| `ackTimeoutMs`              | `number`                          | `3001`                             | No          | Milliseconds to wait for `ack()` before returning a timeout error.      |
-| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No3         | Your app's client ID (required for OAuth).                              |
-| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`  | No3         | Your app's client secret (required for OAuth).                          |
-| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`   | No3         | Secret for OAuth CSRF state parameter.                                  |
-| `scopes`                    | `string[]`                        | `ScopesResolver`                   | `undefined` | No                                                                      | Bot scopes to request during OAuth. Can be a function for dynamic scopes. |
-| `redirectUri`               | `string`                          | `undefined`                        | No          | Redirect URI registered with your Slack app.                            |
-| `installationStore`         | `InstallationStore`2              | `undefined`                        | No4         | Persistent storage backend for OAuth installations.                     |
-| `installerOptions`          | `VercelInstallerOptions`          | `{}`                               | No          | Advanced OAuth options (user scopes, direct install, state store, etc). |
+| Name                        | Type                              | Default Value                      | Required       | Description                                                             |
+| --------------------------- | --------------------------------- | ---------------------------------- | -------------- | ----------------------------------------------------------------------- |
+| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET` | No<sup>1</sup> | Signing secret for your Slack app used to verify requests.              |
+| `signatureVerification`     | `boolean`                         | `true`                             | No             | Enable or disable request signature verification.                       |
+| `logger`                    | `Logger`<sup>2</sup>              | `new ConsoleLogger()`              | No             | Logger used for diagnostics.                                            |
+| `logLevel`                  | `LogLevel`<sup>2</sup>            | `LogLevel.INFO`                    | No             | Minimum log level for the logger.                                       |
+| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No             | Return value is merged into Bolt event `customProperties`<sup>2</sup>.  |
+| `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No             | Intercept requests before Bolt processing.                              |
+| `ackTimeoutMs`              | `number`                          | `3001`                             | No             | Milliseconds to wait for `ack()` before returning a timeout error.      |
+| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No<sup>3</sup> | Your app's client ID (required for OAuth).                              |
+| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`  | No<sup>3</sup> | Your app's client secret (required for OAuth).                          |
+| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`   | No<sup>3</sup> | Secret for OAuth CSRF state parameter.                                  |
+| `scopes`                    | `string[] \| ScopesResolver`      | `undefined`                        | No             | Bot scopes for OAuth. Can be a function for dynamic scopes.             |
+| `redirectUri`               | `string`                          | `undefined`                        | No             | Redirect URI registered with your Slack app.                            |
+| `installationStore`         | `InstallationStore`<sup>2</sup>   | `undefined`                        | No<sup>4</sup> | Persistent storage backend for OAuth installations.                     |
+| `installerOptions`          | `VercelInstallerOptions`          | `{}`                               | No             | Advanced OAuth options (user scopes, direct install, state store, etc). |
 
-1 Optional if `process.env.SLACK_SIGNING_SECRET` is provided.
+<sup>1</sup> Optional if `process.env.SLACK_SIGNING_SECRET` is provided.
 
-2 Provided by the `[@slack/bolt](https://www.npmjs.com/package/@slack/bolt)` library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
+<sup>2</sup> Provided by the [`@slack/bolt`](https://www.npmjs.com/package/@slack/bolt) library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
 
-3 Required for OAuth. Read from `process.env` automatically if not provided.
+<sup>3</sup> Required for OAuth. Read from `process.env` automatically if not provided.
 
-4 Required for OAuth in serverless environments -- the default in-memory store does not persist across cold starts.
+<sup>4</sup> Required for OAuth in serverless environments -- the default in-memory store does not persist across cold starts.
 
 ### `createHandler`
 
@@ -91,12 +91,12 @@ export const POST = createHandler(app, receiver);
 
 #### Parameters
 
-| Name       | Type             | Required | Description                                                  |
-| ---------- | ---------------- | -------- | ------------------------------------------------------------ |
-| `app`      | `App`1           | Yes      | Your Bolt app                                                |
-| `receiver` | `VercelReceiver` | Yes      | The Vercel receiver instance used to process Slack requests. |
+| Name       | Type              | Required | Description                                                  |
+| ---------- | ----------------- | -------- | ------------------------------------------------------------ |
+| `app`      | `App`<sup>1</sup> | Yes      | Your Bolt app                                                |
+| `receiver` | `VercelReceiver`  | Yes      | The Vercel receiver instance used to process Slack requests. |
 
-1 Provided by the `[@slack/bolt](https://www.npmjs.com/package/@slack/bolt)` library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
+<sup>1</sup> Provided by the [`@slack/bolt`](https://www.npmjs.com/package/@slack/bolt) library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
 
 ## OAuth (Multi-Tenant Apps)
 
@@ -253,12 +253,12 @@ Place a [Slack app manifest](https://api.slack.com/reference/manifests) in your 
 
 Add the following to your Vercel project:
 
-| Variable                     | Required | Description                                                                                                                                                                                                     |
-| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SLACK_CONFIGURATION_TOKEN`  | Yes      | App configuration token. Generate at [https://api.slack.com/apps](https://api.slack.com/apps). Expires after 12 hours.                                                                                          |
-| `SLACK_CONFIG_REFRESH_TOKEN` | No       | Refresh token for automatic rotation of expired configuration tokens. Provided alongside the configuration token. Strongly recommended.                                                                         |
-| `VERCEL_API_TOKEN`           | Yes      | Vercel API token with write access. Create at [https://vercel.com/account/settings/tokens](https://vercel.com/account/settings/tokens)                                                                          |
-| `SLACK_SERVICE_TOKEN`        | No       | Service token for auto-installing the app. Without this, the app must be installed manually. See [https://docs.slack.dev/authentication/tokens/#service](https://docs.slack.dev/authentication/tokens/#service) |
+| Variable                     | Required | Description                                                                                                                                            |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SLACK_CONFIGURATION_TOKEN`  | Yes      | App configuration token. Generate at https://api.slack.com/apps. Expires after 12 hours.                                                               |
+| `SLACK_CONFIG_REFRESH_TOKEN` | No       | Refresh token for automatic rotation of expired configuration tokens. Provided alongside the configuration token. Strongly recommended.                |
+| `VERCEL_API_TOKEN`           | Yes      | Vercel API token with write access. Create at https://vercel.com/account/settings/tokens                                                               |
+| `SLACK_SERVICE_TOKEN`        | No       | Service token for auto-installing the app. Without this, the app must be installed manually. See https://docs.slack.dev/authentication/tokens/#service |
 
 You must also enable **Automatically expose System Environment Variables** in your Vercel project settings.
 
@@ -304,19 +304,12 @@ All Vercel and Slack environment variables are read automatically. You can overr
 
 ### Request Interception
 
-The `beforeProcess` hook lets you intercept requests after signature verification but before Bolt processes them. Return a `Response` to short-circuit processing, or `undefined` to continue normally.
-
-This is useful for:
-
-- Routing certain workspaces to different backends
-- Custom logging or metrics
-- Early rejection based on request content
+The `beforeProcess` hook lets you intercept requests after signature verification but before Bolt processes them. Return a `Response` to short-circuit, or `undefined` to continue normally.
 
 ```typescript
 const receiver = new VercelReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   beforeProcess: async (req, body) => {
-    // Forward enterprise workspaces to a dedicated service
     if (body.team_id === "T_ENTERPRISE") {
       return fetch("https://enterprise-handler.example.com/slack", {
         method: "POST",
@@ -329,7 +322,7 @@ const receiver = new VercelReceiver({
 });
 ```
 
-> **Note:** `beforeProcess` is not called for `url_verification` challenge requests, which are handled automatically.
+> **Note:** `beforeProcess` is not called for `url_verification` challenges.
 
 ### Dynamic Scopes
 

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -1,7 +1,7 @@
 # @vercel/slack-bolt
 
-[npm version](https://www.npmjs.com/package/@vercel/slack-bolt)
-[npm downloads](https://www.npmjs.com/package/@vercel/slack-bolt)
+[![npm version](https://img.shields.io/npm/v/%40vercel%2Fslack-bolt)](https://www.npmjs.com/package/@vercel/slack-bolt)
+[![npm downloads](https://img.shields.io/npm/dm/%40vercel%2Fslack-bolt?label=downloads)](https://www.npmjs.com/package/@vercel/slack-bolt)
 
 A custom [Slack Bolt](https://slack.dev/bolt-js/) receiver built for Vercel's [Fluid Compute](https://vercel.com/docs/fluid-compute).
 

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -51,24 +51,22 @@ export { app, receiver };
 
 #### Parameters
 
-
-| Name                        | Type                              | Default Value                      | Required | Description                                                               |
-| --------------------------- | --------------------------------- | ---------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET` | No1      | Signing secret for your Slack app used to verify requests.                |
-| `signatureVerification`     | `boolean`                         | `true`                             | No       | Enable or disable request signature verification.                         |
-| `logger`                    | `Logger`2                         | `new ConsoleLogger()`              | No       | Logger used for diagnostics.                                              |
-| `logLevel`                  | `LogLevel`2                       | `LogLevel.INFO`                    | No       | Minimum log level for the logger.                                         |
-| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No       | Return value is merged into Bolt event `customProperties`2.               |
-| `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No       | Intercept requests before Bolt processing.                                |
-| `ackTimeoutMs`              | `number`                          | `3001`                             | No       | Milliseconds to wait for `ack()` before returning a timeout error.        |
-| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No3      | Your app's client ID (required for OAuth).                                |
-| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`  | No3      | Your app's client secret (required for OAuth).                            |
-| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`   | No3      | Secret for OAuth CSRF state parameter.                                    |
-| `scopes`                    | `string[] | ScopesResolver`       | `undefined`                        | No       | Bot scopes to request during OAuth. Can be a function for dynamic scopes. |
-| `redirectUri`               | `string`                          | `undefined`                        | No       | Redirect URI registered with your Slack app.                              |
-| `installationStore`         | `InstallationStore`2              | `undefined`                        | No4      | Persistent storage backend for OAuth installations.                       |
-| `installerOptions`          | `VercelInstallerOptions`          | `{}`                               | No       | Advanced OAuth options (user scopes, direct install, state store, etc).   |
-
+| Name                        | Type                              | Default Value                      | Required    | Description                                                             |
+| --------------------------- | --------------------------------- | ---------------------------------- | ----------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `signingSecret`             | `string`                          | `process.env.SLACK_SIGNING_SECRET` | No1         | Signing secret for your Slack app used to verify requests.              |
+| `signatureVerification`     | `boolean`                         | `true`                             | No          | Enable or disable request signature verification.                       |
+| `logger`                    | `Logger`2                         | `new ConsoleLogger()`              | No          | Logger used for diagnostics.                                            |
+| `logLevel`                  | `LogLevel`2                       | `LogLevel.INFO`                    | No          | Minimum log level for the logger.                                       |
+| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No          | Return value is merged into Bolt event `customProperties`2.             |
+| `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No          | Intercept requests before Bolt processing.                              |
+| `ackTimeoutMs`              | `number`                          | `3001`                             | No          | Milliseconds to wait for `ack()` before returning a timeout error.      |
+| `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No3         | Your app's client ID (required for OAuth).                              |
+| `clientSecret`              | `string`                          | `process.env.SLACK_CLIENT_SECRET`  | No3         | Your app's client secret (required for OAuth).                          |
+| `stateSecret`               | `string`                          | `process.env.SLACK_STATE_SECRET`   | No3         | Secret for OAuth CSRF state parameter.                                  |
+| `scopes`                    | `string[]`                        | `ScopesResolver`                   | `undefined` | No                                                                      | Bot scopes to request during OAuth. Can be a function for dynamic scopes. |
+| `redirectUri`               | `string`                          | `undefined`                        | No          | Redirect URI registered with your Slack app.                            |
+| `installationStore`         | `InstallationStore`2              | `undefined`                        | No4         | Persistent storage backend for OAuth installations.                     |
+| `installerOptions`          | `VercelInstallerOptions`          | `{}`                               | No          | Advanced OAuth options (user scopes, direct install, state store, etc). |
 
 1 Optional if `process.env.SLACK_SIGNING_SECRET` is provided.
 
@@ -93,12 +91,10 @@ export const POST = createHandler(app, receiver);
 
 #### Parameters
 
-
 | Name       | Type             | Required | Description                                                  |
 | ---------- | ---------------- | -------- | ------------------------------------------------------------ |
 | `app`      | `App`1           | Yes      | Your Bolt app                                                |
 | `receiver` | `VercelReceiver` | Yes      | The Vercel receiver instance used to process Slack requests. |
-
 
 1 Provided by the `[@slack/bolt](https://www.npmjs.com/package/@slack/bolt)` library. More information [here](https://docs.slack.dev/tools/bolt-js/reference#app-options).
 
@@ -110,14 +106,12 @@ export const POST = createHandler(app, receiver);
 
 Set these in your Vercel project (or `.env.local` for local development):
 
-
 | Variable               | Description                                                                                      |
 | ---------------------- | ------------------------------------------------------------------------------------------------ |
 | `SLACK_CLIENT_ID`      | App client ID, found under **Basic Information** on [api.slack.com](https://api.slack.com/apps). |
 | `SLACK_CLIENT_SECRET`  | App client secret, found in the same section.                                                    |
 | `SLACK_STATE_SECRET`   | A random string used to sign the OAuth state parameter.                                          |
 | `SLACK_SIGNING_SECRET` | Signing secret for verifying incoming Slack requests.                                            |
-
 
 All four are read from `process.env` automatically.
 
@@ -186,7 +180,6 @@ const result = await preview({
 
 #### Parameters (`PreviewParams`)
 
-
 | Name                      | Type     | Required | Description                                                      |
 | ------------------------- | -------- | -------- | ---------------------------------------------------------------- |
 | `branch`                  | `string` | Yes      | Git branch name for the preview deployment.                      |
@@ -205,16 +198,13 @@ const result = await preview({
 | `commitMessage`           | `string` | No       | Git commit message (displayed in the Slack app description).     |
 | `commitAuthor`            | `string` | No       | Git commit author (displayed in the Slack app description).      |
 
-
 #### Return value (`PreviewResult`)
-
 
 | Name            | Type      | Description                                                       |
 | --------------- | --------- | ----------------------------------------------------------------- |
 | `isNew`         | `boolean` | `true` if a new Slack app was created, `false` if updated.        |
 | `installStatus` | `string`  | Installation outcome (e.g. `installed`, `missing_service_token`). |
 | `app`           | `object`  | Slack API response containing `app_id` and credentials.           |
-
 
 ## Preview Deployments
 
@@ -263,14 +253,12 @@ Place a [Slack app manifest](https://api.slack.com/reference/manifests) in your 
 
 Add the following to your Vercel project:
 
-
 | Variable                     | Required | Description                                                                                                                                                                                                     |
 | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SLACK_CONFIGURATION_TOKEN`  | Yes      | App configuration token. Generate at [https://api.slack.com/apps](https://api.slack.com/apps). Expires after 12 hours.                                                                                          |
 | `SLACK_CONFIG_REFRESH_TOKEN` | No       | Refresh token for automatic rotation of expired configuration tokens. Provided alongside the configuration token. Strongly recommended.                                                                         |
 | `VERCEL_API_TOKEN`           | Yes      | Vercel API token with write access. Create at [https://vercel.com/account/settings/tokens](https://vercel.com/account/settings/tokens)                                                                          |
 | `SLACK_SERVICE_TOKEN`        | No       | Service token for auto-installing the app. Without this, the app must be installed manually. See [https://docs.slack.dev/authentication/tokens/#service](https://docs.slack.dev/authentication/tokens/#service) |
-
 
 You must also enable **Automatically expose System Environment Variables** in your Vercel project settings.
 
@@ -329,9 +317,9 @@ const receiver = new VercelReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   beforeProcess: async (req, body) => {
     // Forward enterprise workspaces to a dedicated service
-    if (body.team_id === 'T_ENTERPRISE') {
-      return fetch('https://enterprise-handler.example.com/slack', {
-        method: 'POST',
+    if (body.team_id === "T_ENTERPRISE") {
+      return fetch("https://enterprise-handler.example.com/slack", {
+        method: "POST",
         body: await req.text(),
         headers: req.headers,
       });
@@ -355,11 +343,11 @@ const receiver = new VercelReceiver({
   installationStore: myInstallationStore,
   scopes: async (req) => {
     const url = new URL(req.url);
-    const isEnterprise = url.searchParams.get('enterprise') === 'true';
-    
-    const baseScopes = ['chat:write', 'commands'];
+    const isEnterprise = url.searchParams.get("enterprise") === "true";
+
+    const baseScopes = ["chat:write", "commands"];
     if (isEnterprise) {
-      return [...baseScopes, 'users:read', 'channels:read'];
+      return [...baseScopes, "users:read", "channels:read"];
     }
     return baseScopes;
   },
@@ -383,4 +371,3 @@ For issues and questions:
 - Check the [Slack Bolt documentation](https://slack.dev/bolt-js/)
 - Review [Vercel Functions documentation](https://vercel.com/docs/functions)
 - [Open an issue](https://github.com/vercel-labs/slack-bolt/issues) in this repository
-

--- a/packages/slack-bolt/src/index.test.ts
+++ b/packages/slack-bolt/src/index.test.ts
@@ -219,6 +219,50 @@ describe("VercelReceiver", () => {
         ),
       ).rejects.toThrow("OAuth is not configured");
     });
+
+    it("should accept scopes as a static array", () => {
+      const receiver = new VercelReceiver({
+        signingSecret: "test-secret",
+        clientId: "cid",
+        clientSecret: "csec",
+        stateSecret: "ssec",
+        scopes: ["chat:write", "channels:read"],
+        installationStore: {
+          storeInstallation: async () => {},
+          fetchInstallation: async () => ({}) as never,
+        },
+      });
+
+      expect(receiver.installer).toBeDefined();
+      expect(receiver).toHaveProperty("installUrlOptions");
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      expect((receiver as any).installUrlOptions?.scopes).toEqual([
+        "chat:write",
+        "channels:read",
+      ]);
+    });
+
+    it("should accept scopes as a resolver function", () => {
+      const scopesResolver = vi.fn().mockResolvedValue(["chat:write"]);
+      const receiver = new VercelReceiver({
+        signingSecret: "test-secret",
+        clientId: "cid",
+        clientSecret: "csec",
+        stateSecret: "ssec",
+        scopes: scopesResolver,
+        installationStore: {
+          storeInstallation: async () => {},
+          fetchInstallation: async () => ({}) as never,
+        },
+      });
+
+      expect(receiver.installer).toBeDefined();
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      expect((receiver as any).scopesResolver).toBe(scopesResolver);
+      // When using a resolver, installUrlOptions.scopes starts empty
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      expect((receiver as any).installUrlOptions?.scopes).toEqual([]);
+    });
   });
 
   describe("getLogger", () => {
@@ -1279,6 +1323,126 @@ describe("VercelReceiver", () => {
 
         // Late ack should throw an error indicating it was too late
         expect(ackError).toBeInstanceOf(ReceiverMultipleAckError);
+      });
+    });
+
+    describe("beforeProcess", () => {
+      it("should call beforeProcess with request and parsed body", async () => {
+        const beforeProcess = vi.fn();
+        const receiver = new VercelReceiver({
+          signingSecret: "test-secret",
+          signatureVerification: false,
+          beforeProcess,
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: we're mocking the handleSlackEvent method
+        vi.spyOn(receiver as any, "handleSlackEvent").mockResolvedValue(
+          new Response("", { status: 200 }),
+        );
+
+        const handler = receiver.toHandler();
+        const payload = { type: "event_callback", team_id: "T123" };
+        const request = new Request("http://localhost", {
+          method: "POST",
+          body: JSON.stringify(payload),
+          headers: { "content-type": "application/json" },
+        });
+
+        await handler(request);
+
+        expect(beforeProcess).toHaveBeenCalledTimes(1);
+        expect(beforeProcess).toHaveBeenCalledWith(
+          expect.any(Request),
+          payload,
+        );
+      });
+
+      it("should short-circuit when beforeProcess returns a Response", async () => {
+        const customResponse = new Response("intercepted", { status: 202 });
+        const beforeProcess = vi.fn().mockResolvedValue(customResponse);
+        const receiver = new VercelReceiver({
+          signingSecret: "test-secret",
+          signatureVerification: false,
+          beforeProcess,
+        });
+
+        const handleSlackEventSpy = vi.spyOn(
+          // biome-ignore lint/suspicious/noExplicitAny: we're mocking the handleSlackEvent method
+          receiver as any,
+          "handleSlackEvent",
+        );
+
+        const handler = receiver.toHandler();
+        const request = new Request("http://localhost", {
+          method: "POST",
+          body: JSON.stringify({ type: "event_callback" }),
+          headers: { "content-type": "application/json" },
+        });
+
+        const response = await handler(request);
+
+        expect(response.status).toBe(202);
+        expect(await response.text()).toBe("intercepted");
+        expect(handleSlackEventSpy).not.toHaveBeenCalled();
+      });
+
+      it("should continue to handleSlackEvent when beforeProcess returns void", async () => {
+        const beforeProcess = vi.fn().mockResolvedValue(undefined);
+        const receiver = new VercelReceiver({
+          signingSecret: "test-secret",
+          signatureVerification: false,
+          beforeProcess,
+        });
+
+        const handleSlackEventSpy = vi
+          // biome-ignore lint/suspicious/noExplicitAny: we're mocking the handleSlackEvent method
+          .spyOn(receiver as any, "handleSlackEvent")
+          .mockResolvedValue(new Response("", { status: 200 }));
+
+        const handler = receiver.toHandler();
+        const request = new Request("http://localhost", {
+          method: "POST",
+          body: JSON.stringify({ type: "event_callback" }),
+          headers: { "content-type": "application/json" },
+        });
+
+        await handler(request);
+
+        expect(beforeProcess).toHaveBeenCalled();
+        expect(handleSlackEventSpy).toHaveBeenCalled();
+      });
+
+      it("should provide a request with readable body to beforeProcess", async () => {
+        let capturedBody: string | undefined;
+        const beforeProcess = vi
+          .fn()
+          .mockImplementation(async (req: Request) => {
+            capturedBody = await req.text();
+            return undefined;
+          });
+
+        const receiver = new VercelReceiver({
+          signingSecret: "test-secret",
+          signatureVerification: false,
+          beforeProcess,
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: we're mocking the handleSlackEvent method
+        vi.spyOn(receiver as any, "handleSlackEvent").mockResolvedValue(
+          new Response("", { status: 200 }),
+        );
+
+        const handler = receiver.toHandler();
+        const payload = { type: "event_callback", team_id: "T123" };
+        const request = new Request("http://localhost", {
+          method: "POST",
+          body: JSON.stringify(payload),
+          headers: { "content-type": "application/json" },
+        });
+
+        await handler(request);
+
+        expect(capturedBody).toBe(JSON.stringify(payload));
       });
     });
   });

--- a/packages/slack-bolt/src/index.test.ts
+++ b/packages/slack-bolt/src/index.test.ts
@@ -263,6 +263,75 @@ describe("VercelReceiver", () => {
       // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
       expect((receiver as any).installUrlOptions?.scopes).toEqual([]);
     });
+
+    it("should call scopes resolver with request during handleInstall", async () => {
+      const scopesResolver = vi
+        .fn()
+        .mockResolvedValue(["chat:write", "users:read"]);
+      const receiver = new VercelReceiver({
+        signingSecret: "test-secret",
+        clientId: "cid",
+        clientSecret: "csec",
+        stateSecret: "ssec",
+        scopes: scopesResolver,
+        installationStore: {
+          storeInstallation: async () => {},
+          fetchInstallation: async () => ({}) as never,
+        },
+      });
+
+      // Mock the installer's handleInstallPath to capture the options passed
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      let capturedInstallUrlOptions: any;
+      vi.spyOn(receiver.installer!, "handleInstallPath").mockImplementation(
+        async (_req, res, _pathOpts, urlOpts) => {
+          capturedInstallUrlOptions = urlOpts;
+          res.writeHead(302, { Location: "https://slack.com/oauth" });
+          res.end();
+        },
+      );
+
+      const request = new Request("https://example.com/install?team=T123");
+      await receiver.handleInstall(request);
+
+      expect(scopesResolver).toHaveBeenCalledTimes(1);
+      expect(scopesResolver).toHaveBeenCalledWith(expect.any(Request));
+      expect(capturedInstallUrlOptions?.scopes).toEqual([
+        "chat:write",
+        "users:read",
+      ]);
+    });
+
+    it("should use static scopes array without calling resolver", async () => {
+      const receiver = new VercelReceiver({
+        signingSecret: "test-secret",
+        clientId: "cid",
+        clientSecret: "csec",
+        stateSecret: "ssec",
+        scopes: ["chat:write"],
+        installationStore: {
+          storeInstallation: async () => {},
+          fetchInstallation: async () => ({}) as never,
+        },
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      let capturedInstallUrlOptions: any;
+      vi.spyOn(receiver.installer!, "handleInstallPath").mockImplementation(
+        async (_req, res, _pathOpts, urlOpts) => {
+          capturedInstallUrlOptions = urlOpts;
+          res.writeHead(302, { Location: "https://slack.com/oauth" });
+          res.end();
+        },
+      );
+
+      const request = new Request("https://example.com/install");
+      await receiver.handleInstall(request);
+
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private property for test
+      expect((receiver as any).scopesResolver).toBeUndefined();
+      expect(capturedInstallUrlOptions?.scopes).toEqual(["chat:write"]);
+    });
   });
 
   describe("getLogger", () => {

--- a/packages/slack-bolt/src/index.ts
+++ b/packages/slack-bolt/src/index.ts
@@ -39,10 +39,33 @@ export type VercelHandler = (req: Request) => Promise<Response>;
 
 /**
  * A function that can intercept requests before they are processed by Bolt.
- * Return a Response to short-circuit processing, or void/undefined to continue.
- * @param req - The original request
+ * Return a Response to short-circuit processing, or undefined to continue.
+ *
+ * Called after signature verification and body parsing, but before Bolt event handling.
+ * Note: This hook is NOT called for `url_verification` challenge requests, which are
+ * handled automatically before `beforeProcess` is invoked.
+ *
+ * @param req - A new Request with the raw body (the original request body was consumed during parsing)
  * @param body - The parsed request body
- * @returns A Response to short-circuit, or void to continue normal processing
+ * @returns A Response to short-circuit processing, or undefined to continue to Bolt
+ *
+ * @example
+ * ```typescript
+ * const receiver = new VercelReceiver({
+ *   signingSecret: process.env.SLACK_SIGNING_SECRET,
+ *   beforeProcess: async (req, body) => {
+ *     // Forward certain workspaces to a different service
+ *     if (body.team_id === 'T_ENTERPRISE') {
+ *       return fetch('https://enterprise-handler.example.com/slack', {
+ *         method: 'POST',
+ *         body: await req.text(),
+ *         headers: req.headers,
+ *       });
+ *     }
+ *     // Return undefined to continue normal Bolt processing
+ *   },
+ * });
+ * ```
  */
 export type BeforeProcessFn = (
   req: Request,
@@ -120,8 +143,10 @@ export interface VercelReceiverOptions {
   /**
    * A function that can intercept requests before they are processed by Bolt.
    * Return a Response to short-circuit processing (e.g., to forward to an external service),
-   * or void/undefined to continue normal Bolt processing.
-   * Called after signature verification but before event handling.
+   * or undefined to continue normal Bolt processing.
+   *
+   * Called after signature verification and body parsing, but before Bolt event handling.
+   * Note: Not called for `url_verification` challenge requests.
    * @default undefined
    */
   beforeProcess?: BeforeProcessFn;

--- a/packages/slack-bolt/src/index.ts
+++ b/packages/slack-bolt/src/index.ts
@@ -38,6 +38,26 @@ import { createResponseCapture, toIncomingMessage } from "./oauth-adapters";
 export type VercelHandler = (req: Request) => Promise<Response>;
 
 /**
+ * A function that can intercept requests before they are processed by Bolt.
+ * Return a Response to short-circuit processing, or void/undefined to continue.
+ * @param req - The original request
+ * @param body - The parsed request body
+ * @returns A Response to short-circuit, or void to continue normal processing
+ */
+export type BeforeProcessFn = (
+  req: Request,
+  body: StringIndexed,
+) => Promise<Response | undefined> | Response | undefined;
+
+/**
+ * A function that resolves scopes dynamically based on the request.
+ * Useful for requesting different scopes based on team or user context.
+ * @param req - The original request
+ * @returns The scopes to request
+ */
+export type ScopesResolver = (req: Request) => Promise<string[]> | string[];
+
+/**
  * Configuration options for the VercelReceiver.
  * @property signingSecret - The signing secret for the Slack app.
  * @property signatureVerification - If true, verifies the Slack request signature.
@@ -98,6 +118,14 @@ export interface VercelReceiverOptions {
    */
   customPropertiesExtractor?: (req: Request) => StringIndexed;
   /**
+   * A function that can intercept requests before they are processed by Bolt.
+   * Return a Response to short-circuit processing (e.g., to forward to an external service),
+   * or void/undefined to continue normal Bolt processing.
+   * Called after signature verification but before event handling.
+   * @default undefined
+   */
+  beforeProcess?: BeforeProcessFn;
+  /**
    * The timeout in milliseconds for event acknowledgment.
    * @default 3001
    */
@@ -122,8 +150,10 @@ export interface VercelReceiverOptions {
   stateSecret?: string;
   /**
    * The bot scopes to request during the OAuth flow.
+   * Can be a static array or a function that resolves scopes dynamically
+   * based on the request (e.g., to request different scopes for different teams).
    */
-  scopes?: string[];
+  scopes?: string[] | ScopesResolver;
   /**
    * The redirect URI registered with your Slack app for OAuth callbacks.
    */
@@ -228,11 +258,13 @@ export class VercelReceiver implements Receiver {
   private readonly signatureVerification: boolean;
   private readonly logger: Logger;
   private readonly customPropertiesExtractor?: (req: Request) => StringIndexed;
+  private readonly beforeProcess?: BeforeProcessFn;
   private readonly ackTimeoutMs: number;
   private app?: App;
 
   public installer?: InstallProvider;
   private installUrlOptions?: InstallURLOptions;
+  private scopesResolver?: ScopesResolver;
   private installCallbackOptions?: CallbackOptions;
   private installPathOptions?: InstallPathOptions;
   private stateVerification?: boolean;
@@ -262,6 +294,7 @@ export class VercelReceiver implements Receiver {
     logger,
     logLevel = LogLevel.INFO,
     customPropertiesExtractor,
+    beforeProcess,
     ackTimeoutMs = ACK_TIMEOUT_MS,
     clientId = process.env.SLACK_CLIENT_ID,
     clientSecret = process.env.SLACK_CLIENT_SECRET,
@@ -282,6 +315,7 @@ export class VercelReceiver implements Receiver {
       logLevel,
     );
     this.customPropertiesExtractor = customPropertiesExtractor;
+    this.beforeProcess = beforeProcess;
     this.ackTimeoutMs = ackTimeoutMs;
 
     this.stateVerification = installerOptions.stateVerification;
@@ -313,12 +347,23 @@ export class VercelReceiver implements Receiver {
         authorizationUrl: installerOptions.authorizationUrl,
       });
 
-      this.installUrlOptions = {
-        scopes: scopes ?? [],
-        userScopes: installerOptions.userScopes,
-        metadata: installerOptions.metadata,
-        redirectUri,
-      };
+      // If scopes is a function, store it separately for dynamic resolution
+      if (typeof scopes === "function") {
+        this.scopesResolver = scopes;
+        this.installUrlOptions = {
+          scopes: [], // Will be resolved dynamically in handleInstall
+          userScopes: installerOptions.userScopes,
+          metadata: installerOptions.metadata,
+          redirectUri,
+        };
+      } else {
+        this.installUrlOptions = {
+          scopes: scopes ?? [],
+          userScopes: installerOptions.userScopes,
+          metadata: installerOptions.metadata,
+          redirectUri,
+        };
+      }
       this.installCallbackOptions = installerOptions.callbackOptions ?? {};
       this.installPathOptions = installerOptions.installPathOptions ?? {};
     }
@@ -367,11 +412,21 @@ export class VercelReceiver implements Receiver {
     const nodeReq = toIncomingMessage(req);
     const capture = createResponseCapture();
 
+    // Resolve scopes dynamically if a resolver function was provided
+    let installUrlOptions = this.installUrlOptions;
+    if (this.scopesResolver && installUrlOptions) {
+      const resolvedScopes = await this.scopesResolver(req);
+      installUrlOptions = {
+        ...installUrlOptions,
+        scopes: resolvedScopes,
+      };
+    }
+
     await this.installer.handleInstallPath(
       nodeReq,
       capture,
       this.installPathOptions,
-      this.installUrlOptions,
+      installUrlOptions,
     );
 
     return capture.toResponse();
@@ -428,6 +483,21 @@ export class VercelReceiver implements Receiver {
         if (body.type === "url_verification") {
           this.logger.debug("Handling URL verification challenge");
           return Response.json({ challenge: body.challenge });
+        }
+
+        // Allow beforeProcess to intercept and short-circuit processing.
+        // We pass a new Request with the raw body since req.text() was already consumed.
+        if (this.beforeProcess) {
+          const reqWithBody = new Request(req.url, {
+            method: req.method,
+            headers: req.headers,
+            body: rawBody,
+          });
+          const interceptResponse = await this.beforeProcess(reqWithBody, body);
+          if (interceptResponse) {
+            this.logger.debug("Request intercepted by beforeProcess");
+            return interceptResponse;
+          }
         }
 
         return await this.handleSlackEvent(req, body);


### PR DESCRIPTION
Adding 2 new features that I'd like for the Vercel Slack integration – 

1. `beforeProcess` function – enables forwarding to external services depending on workspace and event type 
2. Dynamic `scope` resolution – enables us to enable elevated scopes (subset of approved scopes) for different teams/workspaces behind feature flags. 