### PR TITLE
[ci] use github-api commit mode

### DIFF
--- a/.changeset/dependabot-npm-and-yarn-vercel-functions-3-5-0.md
+++ b/.changeset/dependabot-npm-and-yarn-vercel-functions-3-5-0.md
@@ -1,5 +1,0 @@
----
-"@vercel/slack-bolt": patch
----
-
-bump deps

--- a/.changeset/olive-news-beam.md
+++ b/.changeset/olive-news-beam.md
@@ -1,5 +1,0 @@
----
-"@vercel/slack-bolt": minor
----
-
-Adding before process function + dynamic scope resolution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -52,5 +50,6 @@ jobs:
           version: pnpm version-packages
           commit: "chore: update package versions"
           title: "chore: update package versions"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/slack-bolt/CHANGELOG.md
+++ b/packages/slack-bolt/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @vercel/slack-bolt
 
+## 1.5.0
+
+### Minor Changes
+
+- 3d56462: Adding before process function + dynamic scope resolution
+
+### Patch Changes
+
+- fd4a7c3: bump deps
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/slack-bolt/package.json
+++ b/packages/slack-bolt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/slack-bolt",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A Vercel receiver for building Slack apps with Bolt and deploying them to Vercel",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
1. Using `github-api` commit mode 
2. Using default `GITHUB_TOKEN` instead of this secret, which I believe may have been removed post Obsidian. 