### PR TITLE
[slack-bolt] add request body to customPropertiesExtractor params

### DIFF
--- a/.changeset/tender-nights-cross.md
+++ b/.changeset/tender-nights-cross.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": patch
+---
+
+Adding parsed body to customPropertiesExtractor params

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -57,7 +57,7 @@ export { app, receiver };
 | `signatureVerification`     | `boolean`                         | `true`                             | No             | Enable or disable request signature verification.                       |
 | `logger`                    | `Logger`<sup>2</sup>              | `new ConsoleLogger()`              | No             | Logger used for diagnostics.                                            |
 | `logLevel`                  | `LogLevel`<sup>2</sup>            | `LogLevel.INFO`                    | No             | Minimum log level for the logger.                                       |
-| `customPropertiesExtractor` | `(req: Request) => StringIndexed` | `undefined`                        | No             | Return value is merged into Bolt event `customProperties`<sup>2</sup>.  |
+| `customPropertiesExtractor` | `(req: Request, body: StringIndexed) => StringIndexed` | `undefined`                        | No             | Return value is merged into Bolt event `customProperties`<sup>2</sup>.  |
 | `beforeProcess`             | `BeforeProcessFn`                 | `undefined`                        | No             | Intercept requests before Bolt processing.                              |
 | `ackTimeoutMs`              | `number`                          | `3001`                             | No             | Milliseconds to wait for `ack()` before returning a timeout error.      |
 | `clientId`                  | `string`                          | `process.env.SLACK_CLIENT_ID`      | No<sup>3</sup> | Your app's client ID (required for OAuth).                              |

--- a/packages/slack-bolt/src/index.ts
+++ b/packages/slack-bolt/src/index.ts
@@ -136,10 +136,14 @@ export interface VercelReceiverOptions {
   logLevel?: LogLevel;
   /**
    * A function to extract custom properties from incoming events.
+   * Called after body parsing, so the parsed body is available.
    * @default undefined
    * @returns An object with custom properties.
    */
-  customPropertiesExtractor?: (req: Request) => StringIndexed;
+  customPropertiesExtractor?: (
+    req: Request,
+    body: StringIndexed,
+  ) => StringIndexed;
   /**
    * A function that can intercept requests before they are processed by Bolt.
    * Return a Response to short-circuit processing (e.g., to forward to an external service),
@@ -282,7 +286,10 @@ export class VercelReceiver implements Receiver {
   private readonly signingSecret: string;
   private readonly signatureVerification: boolean;
   private readonly logger: Logger;
-  private readonly customPropertiesExtractor?: (req: Request) => StringIndexed;
+  private readonly customPropertiesExtractor?: (
+    req: Request,
+    body: StringIndexed,
+  ) => StringIndexed;
   private readonly beforeProcess?: BeforeProcessFn;
   private readonly ackTimeoutMs: number;
   private app?: App;
@@ -702,7 +709,7 @@ export class VercelReceiver implements Receiver {
     request: Request;
   }): ReceiverEvent {
     const customProperties = this.customPropertiesExtractor
-      ? this.customPropertiesExtractor(request)
+      ? this.customPropertiesExtractor(request, body)
       : {};
 
     const retryNum = headers.get(SLACK_RETRY_NUM_HEADER) || "0";


### PR DESCRIPTION
Attempting to inject custom context (`installationId` field) from the request body – depending on the workspace (Enterprise install), this may be the `teamId` or `enterpriseId`. 

```
const { installationId } = context;
```