### PR TITLE
chore(dependabot): ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     groups:
       root-dev-dependencies:
         dependency-type: "development"
+    # Major bumps are reviewed/applied manually so breaking changes never land
+    # in an automated dependency PR.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 1
     reviewers:
       - "malewis5"
@@ -23,6 +29,10 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 1
     reviewers:
       - "malewis5"
@@ -37,6 +47,10 @@ updates:
       example-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 1
     reviewers:
       - "malewis5"


### PR DESCRIPTION
## What

Add explicit `ignore` rules for `version-update:semver-major` to the three npm ecosystems (root, `packages/slack-bolt`, `examples/nextjs`) in `.github/dependabot.yml`.

## Why

The groups are already scoped to `minor`/`patch`, but a group's `update-types` only controls **which updates get grouped together** — it does **not** stop Dependabot from proposing majors. That let breaking majors land in automated dependency PRs:

- #160 — `commander` 14 → 15 (ESM-only, requires Node ≥ 22.12)
- #150 — `@types/node` 25 → 26

With these ignore rules, grouped dep PRs stay minor/patch only and majors are reviewed/applied manually.

## Notes

- `github-actions` is intentionally left enabled for majors — #159 (`actions/checkout` 6 → 7) passed cleanly and action majors are low-risk.
- To intentionally take a specific major later, bump it manually or temporarily remove/scope the ignore rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)