### PR TITLE
ci: test on Node 22, 24, 26 and raise minimum Node to >=22

### DIFF
--- a/.changeset/raise-min-node-22.md
+++ b/.changeset/raise-min-node-22.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": minor
+---
+
+Raise minimum supported Node.js version to >=22.0.0 (Node 20 is EOL). CI now tests against Node 22, 24, and 26.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24, 26]
       fail-fast: false
     steps:
       - name: Checkout

--- a/packages/slack-bolt/package.json
+++ b/packages/slack-bolt/package.json
@@ -88,7 +88,7 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What

- CI test matrix: `[20, 22]` → `[22, 24, 26]`
- `@vercel/slack-bolt` `engines.node`: `>=20.0.0` → `>=22.0.0`
- Adds a Changeset (`minor`)

## Why

Node 20 is EOL, so it's dropped from the matrix in favor of the current active/current lines (24, 26). Once Node 20 is no longer tested, declaring `>=20.0.0` is unverified — bumping `engines.node` to `>=22.0.0` keeps the published support range honest and matches the lowest version CI actually runs.

## Notes / decisions for the maintainer

- **Release semver:** changeset is set to `minor` since Node 20 is EOL and this only tightens the declared engine. If you'd rather treat dropping a runtime as breaking, change it to `major`.
- **Other workflows:** `release.yml` and `canary.yml` still pin Node `22`, which remains in the supported range — left unchanged to keep this PR scoped. Happy to bump those to `24` if you'd prefer build/release on the active LTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)