### PR TITLE
fix(example): strip user tokens when user-specific installation lookup falls back

### DIFF
--- a/examples/nextjs/src/lib/installation-store.ts
+++ b/examples/nextjs/src/lib/installation-store.ts
@@ -143,7 +143,22 @@ export const installationStore: InstallationStore = {
           query.teamId || `enterprise:${query.enterpriseId}`;
         throw new Error(`No installation found for team ${teamIdentifier}`);
       }
-      return decryptTokens(data);
+      const installation = decryptTokens(data);
+      if (query.userId) {
+        // The team-level installation stores the installer's user token. When a
+        // different user (without their own stored installation) triggers this
+        // fallback, returning that token would leak the installer's credentials
+        // and cause cross-user authorization confusion. Strip user token fields
+        // so the fallback only provides bot-level data.
+        installation.user = {
+          ...installation.user,
+          token: undefined,
+          refreshToken: undefined,
+          expiresAt: undefined,
+          scopes: undefined,
+        };
+      }
+      return installation;
     } catch (error) {
       if (
         error instanceof Error &&


### PR DESCRIPTION
## Security finding

**Severity:** MEDIUM (slug: cross-tenant-id)
**File:** `examples/nextjs/src/lib/installation-store.ts`

`fetchInstallation` first checks the per-user Redis key when `query.userId` is present, but if that key is missing it silently falls back to the team-level installation and returns it fully decrypted — including the installer's user token. In an app with user scopes/tokens, a request for user B without a stored user installation would receive user A's token, causing cross-user authorization confusion.

## Fix

When `query.userId` is present and the user-specific key is missing, the fallback to the team-level installation now strips all user token fields (`user.token`, `user.refreshToken`, `user.expiresAt`, `user.scopes`) before returning, so the fallback only provides bot-level data and no other user's credentials can leak.

- No error is thrown for missing user keys, so normal bot-token event authorization continues to work for users who never OAuth'd individually.
- A found user-specific installation is returned unchanged.
- The `user` object itself is kept (with its `id`) with token fields set to `undefined`, consistent with the `@slack/oauth` `Installation<'v1' | 'v2', boolean>` type where these fields accept `undefined`.

## Verification

- `pnpm --filter slack-bolt-with-next typecheck` (`tsc --noEmit`) — passes
- `pnpm --filter slack-bolt-with-next lint` (`biome check`) — passes, 25 files checked
- Pre-commit hooks additionally ran the monorepo lint and `@vercel/slack-bolt` test suite (218 tests) — all passed

No changeset added (change is under `examples/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)