### PR TITLE
ci: pin third-party actions to commit SHAs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,15 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
 
@@ -44,7 +44,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
## Finding

**MEDIUM severity supply-chain risk** in `.github/workflows/ci.yml`: the workflow referenced third-party actions by mutable major tags (`actions/checkout@v7`, `actions/setup-node@v7`, `pnpm/action-setup@v6`, `actions/cache@v6`) while `TURBO_TOKEN` / `TURBO_TEAM` secrets are exposed in the job environment on trusted-branch runs. If any of those tags were retargeted to a malicious commit, the action could exfiltrate the secrets or tamper with builds.

## Fix

Pin each third-party action to a full, immutable commit SHA with a trailing version comment (a format dependabot understands and will keep updated):

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`
- `pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9`
- `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0`

Note: the workflow already used `actions/setup-node@v7`, so it was pinned to the latest v7 release (v7.0.0) rather than downgraded. No other changes were made to the file.

## Verification

- Each tag ref was resolved live via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` (dereferencing the annotated tag for `pnpm/action-setup` via `git/tags/<objsha>`), confirming each tag points to the pinned commit.
- Each pinned SHA was confirmed reachable via `gh api repos/<owner>/<repo>/commits/<sha> --jq .sha`.
- YAML syntax validated: `ruby -ryaml -e 'YAML.load_file(...)'` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)