### PR TITLE
ci: pin third-party actions to commit SHAs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,15 +25,15 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         id: pnpm-setup
         with:


### PR DESCRIPTION
## Finding (MEDIUM severity, supply chain)

`.github/workflows/release.yml` grants `contents: write`, `pull-requests: write`, and `id-token: write`, but referenced three third-party actions by mutable major tags (`actions/checkout@v7`, `actions/setup-node@v7`, `pnpm/action-setup@v6`) ahead of the already SHA-pinned `changesets/action` step. A retargeted tag could run attacker-controlled code with repo write access, the `GITHUB_TOKEN`, OIDC token minting, and the npm release path.

## Fix

Pinned the three actions to full commit SHAs with trailing version comments (dependabot-compatible format), using the latest release in each action's existing major line:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`
- `pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9`

Note: the workflow uses `actions/setup-node@v7` (the finding text referenced v6), so it was pinned to v7.0.0 — the latest v7 release — rather than downgraded to v6.5.0.

`changesets/action` was left untouched (already pinned to `a45c4d5 # v1.9.0`). No other changes (permissions, env, steps) were made.

## Verification

- Each SHA was independently verified against the GitHub API: `git/ref/tags/<tag>` resolves to the pinned commit (pnpm/action-setup's annotated tag `v6.0.9` was dereferenced via `git/tags/<objsha>` to commit `0ebf4713...`), and each commit is reachable via `repos/<owner>/<repo>/commits/<sha>`.
- YAML syntax validated: `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')"` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)