### PR TITLE
ci: pin third-party actions to commit SHAs in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,15 +21,15 @@ jobs:
     environment: canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
           run_install: false


### PR DESCRIPTION
## Security finding (MEDIUM, supply chain)

`.github/workflows/canary.yml` grants `id-token: write` and ran third-party actions via mutable major-version tag refs before `npm publish`. If any of those tags were retargeted upstream, attacker-controlled action code could execute with OIDC npm publish privileges.

## Fix

Pins each third-party action in `.github/workflows/canary.yml` to an immutable full commit SHA, with a trailing version comment in the format Dependabot understands:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020` # v7.0.0
- `pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271` # v6.0.9

Note: the finding text referenced `actions/setup-node@v6`, but the workflow was already on `@v7`, so it is pinned to the latest v7 release (v7.0.0) rather than downgrading to v6.5.0. Effective action versions are unchanged; no permissions, env, or job structure were touched.

## Verification

- Each tag was resolved to its commit via the GitHub API (`gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing the annotated tag object for `pnpm/action-setup` via `git/tags/<objsha>`), and each resulting SHA matches the pin.
- Each pinned SHA confirmed reachable: `gh api repos/<owner>/<repo>/commits/<sha> --jq .sha` succeeded for all three.
- YAML validated: `ruby -ryaml -e 'YAML.safe_load(...)'` parses the file successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)