### PR TITLE
fix: prevent secret leakage through Vercel API error messages

### DIFF
--- a/.changeset/redact-vercel-error-bodies.md
+++ b/.changeset/redact-vercel-error-bodies.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": patch
+---
+
+Prevent secret leakage by redacting raw Vercel API error response bodies from error messages on secret-sensitive endpoints (protection bypass and environment variable operations); only the Vercel error code is included.

--- a/packages/slack-bolt/src/internal/vercel/errors.ts
+++ b/packages/slack-bolt/src/internal/vercel/errors.ts
@@ -23,4 +23,40 @@ export class HTTPError extends Error {
     }
     return new HTTPError(message, response.status, response.statusText, body);
   }
+
+  /**
+   * Sanitized variant for endpoints that submit or retrieve secrets.
+   *
+   * Never includes the raw response body in the error message or attaches
+   * it to the error object, since Vercel error bodies may echo submitted
+   * values (e.g. secrets or env var values) and thrown errors end up in
+   * CLI/build logs. At most, the Vercel error `code` (from the standard
+   * `{ "error": { "code": string } }` shape) is included — never
+   * `error.message` and never the raw body.
+   */
+  static async fromResponseRedacted(
+    message: string,
+    response: Response,
+  ): Promise<HTTPError> {
+    let code: string | undefined;
+    try {
+      const data: unknown = JSON.parse(await response.text());
+      if (
+        data !== null &&
+        typeof data === "object" &&
+        "error" in data &&
+        data.error !== null &&
+        typeof data.error === "object" &&
+        "code" in data.error &&
+        typeof data.error.code === "string"
+      ) {
+        code = data.error.code;
+      }
+    } catch {
+      // body unreadable or not JSON, that's fine
+    }
+    const error = new HTTPError(message, response.status, response.statusText);
+    if (code) error.message += ` (code: ${code})`;
+    return error;
+  }
 }

--- a/packages/slack-bolt/src/internal/vercel/index.test.ts
+++ b/packages/slack-bolt/src/internal/vercel/index.test.ts
@@ -127,7 +127,7 @@ describe("updateProtectionBypass", () => {
     );
   });
 
-  it("should include response body in error message when present", async () => {
+  it("should include only the Vercel error code in the error message, never error.message", async () => {
     mockFetch.mockResolvedValueOnce(
       errorResponse(403, "Forbidden", {
         error: { code: "forbidden", message: "Not allowed" },
@@ -138,11 +138,52 @@ describe("updateProtectionBypass", () => {
 
     expect(err).toBeInstanceOf(HTTPError);
     expect(err.message).toBe(
-      'Failed to update protection bypass: 403 Forbidden - {"error":{"code":"forbidden","message":"Not allowed"}}',
+      "Failed to update protection bypass: 403 Forbidden (code: forbidden)",
     );
-    expect(err.body).toBe(
-      '{"error":{"code":"forbidden","message":"Not allowed"}}',
+    expect(err.body).toBeUndefined();
+  });
+
+  it("should not leak a secret echoed in the error body into the error message or object", async () => {
+    const sentinel = "deadbeefdeadbeefdeadbeefdeadbeef";
+    mockFetch.mockResolvedValueOnce(
+      errorResponse(400, "Bad Request", {
+        error: {
+          code: "bad_request",
+          message: `Invalid secret: ${sentinel}`,
+        },
+      }),
     );
+
+    const err = await updateProtectionBypass(defaultArgs).catch((e) => e);
+
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err.status).toBe(400);
+    expect(err.statusText).toBe("Bad Request");
+    expect(err.message).toBe(
+      "Failed to update protection bypass: 400 Bad Request (code: bad_request)",
+    );
+    expect(err.message).not.toContain(sentinel);
+    expect(err.body).toBeUndefined();
+    expect(JSON.stringify(err)).not.toContain(sentinel);
+  });
+
+  it("should not include a non-JSON error body in the error message", async () => {
+    const sentinel = "deadbeefdeadbeefdeadbeefdeadbeef";
+    mockFetch.mockResolvedValueOnce(
+      new Response(`plain text error mentioning ${sentinel}`, {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    const err = await updateProtectionBypass(defaultArgs).catch((e) => e);
+
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err.message).toBe(
+      "Failed to update protection bypass: 500 Internal Server Error",
+    );
+    expect(err.message).not.toContain(sentinel);
+    expect(err.body).toBeUndefined();
   });
 
   it("should propagate network errors from fetch", async () => {
@@ -409,6 +450,40 @@ describe("addEnvironmentVariables", () => {
     expect(err.message).toBe(
       "Failed to create environment variables: 500 Internal Server Error",
     );
+  });
+
+  it("should not leak env var values echoed in the error body into the error message or object", async () => {
+    const sentinel = "super-secret-env-value-sentinel";
+    mockFetch.mockResolvedValueOnce(
+      errorResponse(400, "Bad Request", {
+        error: {
+          code: "invalid_env",
+          message: `Invalid value: ${sentinel}`,
+        },
+      }),
+    );
+
+    const err = await addEnvironmentVariables({
+      ...defaultArgs,
+      envs: [
+        {
+          key: "SECRET",
+          value: sentinel,
+          type: "encrypted" as const,
+          target: ["production" as const],
+        },
+      ],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err.status).toBe(400);
+    expect(err.statusText).toBe("Bad Request");
+    expect(err.message).toBe(
+      "Failed to create environment variables: 400 Bad Request (code: invalid_env)",
+    );
+    expect(err.message).not.toContain(sentinel);
+    expect(err.body).toBeUndefined();
+    expect(JSON.stringify(err)).not.toContain(sentinel);
   });
 
   it("should propagate network errors from fetch", async () => {

--- a/packages/slack-bolt/src/internal/vercel/index.ts
+++ b/packages/slack-bolt/src/internal/vercel/index.ts
@@ -67,7 +67,9 @@ export async function updateProtectionBypass({
   });
 
   if (!response.ok) {
-    throw await HTTPError.fromResponse(
+    // Redacted: the request body contains the generated secret, which the
+    // error response could echo back.
+    throw await HTTPError.fromResponseRedacted(
       "Failed to update protection bypass",
       response,
     );
@@ -105,7 +107,9 @@ export async function addEnvironmentVariables({
   });
 
   if (!response.ok) {
-    throw await HTTPError.fromResponse(
+    // Redacted: the request body contains env var values (potentially
+    // secrets), which the error response could echo back.
+    throw await HTTPError.fromResponseRedacted(
       "Failed to create environment variables",
       response,
     );
@@ -252,7 +256,9 @@ export async function getEnvironmentVariable({
   });
 
   if (!response.ok) {
-    throw await HTTPError.fromResponse(
+    // Redacted: this endpoint returns a decrypted secret value, which the
+    // error response could include.
+    throw await HTTPError.fromResponseRedacted(
       "Failed to fetch environment variable",
       response,
     );


### PR DESCRIPTION
## Security finding

**Severity:** HIGH (secret-in-log)
**File:** `packages/slack-bolt/src/internal/vercel/index.ts` (with root cause in `packages/slack-bolt/src/internal/vercel/errors.ts`)

The Vercel API helpers submit sensitive values — the generated protection-bypass secret in `updateProtectionBypass` and Slack/Vercel env var values in `addEnvironmentVariables` — and on non-2xx responses threw `HTTPError.fromResponse`, which reads the raw upstream response body and embeds it in `Error.message`. These errors are surfaced through CLI console/error logging, so if Vercel echoed any submitted value back in an error body, the secret would land in build logs.

## Fix

- Added `HTTPError.fromResponseRedacted` in `errors.ts`: a sanitized construction path that never puts the raw response body into `Error.message` and never attaches it to the error object. At most it parses the body as JSON and includes only the Vercel error `code` from the standard `{ "error": { "code": string, "message": string } }` shape — never `error.message` and never the raw body, since either could echo submitted values.
- Switched the secret-sensitive call sites to the redacted path: `updateProtectionBypass`, `addEnvironmentVariables`, and `getEnvironmentVariable` (which retrieves a decrypted secret value).
- Non-sensitive endpoints (`getProject`, `cancelDeployment`, `createDeployment`, `getActiveBranches`, `getEnvironmentVariables` list, `deleteEnvironmentVariable`) are unchanged, and `HTTPError`'s public shape (`status`, `statusText`, `body`) remains backward compatible.
- Added a changeset (patch for `@vercel/slack-bolt`).

## Tests

Extended `packages/slack-bolt/src/internal/vercel/index.test.ts`:
- On failed `updateProtectionBypass` / `addEnvironmentVariables` responses whose bodies contain a sentinel secret string, the thrown error message does NOT contain the sentinel but DOES contain the status and the parsed Vercel error code, and `err.body` is undefined (sentinel absent from `JSON.stringify(err)` too).
- Non-JSON error bodies on the redacted path are dropped entirely.

## Verification

- `pnpm --filter @vercel/slack-bolt test`: 6 files, 221 tests passed
- `pnpm --filter @vercel/slack-bolt typecheck`: passed
- `pnpm --filter @vercel/slack-bolt lint` (biome): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)