### PR TITLE
fix: paginate active branches so cleanup cannot delete live Slack apps

### DIFF
--- a/.changeset/paginate-active-branches-cleanup.md
+++ b/.changeset/paginate-active-branches-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": patch
+---
+
+Paginate through all active branches during orphan cleanup so live branches beyond the first 100 are never misclassified as orphaned and their Slack apps deleted

--- a/packages/slack-bolt/src/cleanup.test.ts
+++ b/packages/slack-bolt/src/cleanup.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupOrphanedApps } from "./cleanup";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+describe("cleanupOrphanedApps", () => {
+  const defaultArgs = {
+    projectId: "prj_123",
+    currentBranch: "main",
+    vercelApiToken: "tok_abc",
+    teamId: "team_456",
+    slackConfigurationToken: "xoxe.xoxp-configtoken",
+  };
+
+  it("should not treat a branch that is only present on the second page of active branches as stale", async () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) => ({
+      branch: `branch-${i}`,
+    }));
+
+    mockFetch.mockImplementation((input: string | URL) => {
+      const url = new URL(input.toString());
+
+      if (url.pathname === "/v5/projects/prj_123/branches") {
+        if (url.searchParams.get("until") === "cursor-1") {
+          // Second page: contains the live branch, no further pages.
+          return Promise.resolve(
+            jsonResponse({ branches: [{ branch: "feature-live" }] }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse({ branches: pageOne, until: "cursor-1" }),
+        );
+      }
+
+      if (url.pathname === "/v9/projects/prj_123/env") {
+        return Promise.resolve(
+          jsonResponse({
+            envs: [
+              {
+                id: "env_1",
+                key: "SLACK_APP_ID",
+                gitBranch: "feature-live",
+              },
+            ],
+          }),
+        );
+      }
+
+      throw new Error(`Unexpected fetch call: ${url.toString()}`);
+    });
+
+    await cleanupOrphanedApps(defaultArgs);
+
+    // Two branch pages + one env listing; no Slack app deletion, no env
+    // variable deletion.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    for (const [input, init] of mockFetch.mock.calls) {
+      expect(new URL(input.toString()).hostname).toBe("api.vercel.com");
+      expect(init?.method ?? "GET").not.toBe("DELETE");
+    }
+  });
+
+  it("should abort without deleting anything when fetching active branches fails", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    await expect(cleanupOrphanedApps(defaultArgs)).rejects.toThrow(
+      "Failed to fetch active branches",
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/slack-bolt/src/internal/vercel/index.test.ts
+++ b/packages/slack-bolt/src/internal/vercel/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HTTPError } from "./errors";
 import {
   addEnvironmentVariables,
+  getActiveBranches,
   getProject,
   updateProtectionBypass,
 } from "./index";
@@ -246,6 +247,146 @@ describe("getProject", () => {
     mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
 
     await expect(getProject(defaultArgs)).rejects.toThrow(TypeError);
+  });
+});
+
+describe("getActiveBranches", () => {
+  const defaultArgs = {
+    projectId: "prj_123",
+    token: "tok_abc",
+    teamId: "team_456",
+  };
+
+  function branchPage(names: string[], until?: string) {
+    return okResponse({
+      branches: names.map((branch) => ({ branch })),
+      ...(until !== undefined ? { until } : {}),
+    });
+  }
+
+  it("should send a GET with active=1, limit=100, teamId, and the bearer header", async () => {
+    mockFetch.mockResolvedValueOnce(branchPage(["main"]));
+
+    await getActiveBranches(defaultArgs);
+
+    const [rawUrl, opts] = mockFetch.mock.calls[0];
+    const url = new URL(rawUrl);
+    expect(url.pathname).toBe("/v5/projects/prj_123/branches");
+    expect(url.searchParams.get("active")).toBe("1");
+    expect(url.searchParams.get("limit")).toBe("100");
+    expect(url.searchParams.get("teamId")).toBe("team_456");
+    expect(url.searchParams.has("until")).toBe(false);
+    expect(opts.headers.Authorization).toBe("Bearer tok_abc");
+  });
+
+  it("should return all branches from a single page and make only one request", async () => {
+    mockFetch.mockResolvedValueOnce(branchPage(["main", "feature-a"]));
+
+    const branches = await getActiveBranches(defaultArgs);
+
+    expect(branches).toEqual(new Set(["main", "feature-a"]));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should paginate through all pages and include branches from every page", async () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) => `branch-${i}`);
+    mockFetch
+      .mockResolvedValueOnce(branchPage(pageOne, "cursor-1"))
+      .mockResolvedValueOnce(branchPage(["branch-100", "branch-101"]));
+
+    const branches = await getActiveBranches(defaultArgs);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(branches.size).toBe(102);
+    expect(branches.has("branch-0")).toBe(true);
+    expect(branches.has("branch-99")).toBe(true);
+    expect(branches.has("branch-100")).toBe(true);
+    expect(branches.has("branch-101")).toBe(true);
+  });
+
+  it("should pass the pagination cursor as the until query param on the next request", async () => {
+    mockFetch
+      .mockResolvedValueOnce(branchPage(["a"], "cursor-1"))
+      .mockResolvedValueOnce(branchPage(["b"]));
+
+    await getActiveBranches(defaultArgs);
+
+    const firstUrl = new URL(mockFetch.mock.calls[0][0]);
+    const secondUrl = new URL(mockFetch.mock.calls[1][0]);
+    expect(firstUrl.searchParams.has("until")).toBe(false);
+    expect(secondUrl.searchParams.get("until")).toBe("cursor-1");
+    expect(secondUrl.searchParams.get("active")).toBe("1");
+    expect(secondUrl.searchParams.get("teamId")).toBe("team_456");
+  });
+
+  it("should support numeric until cursors", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        okResponse({ branches: [{ branch: "a" }], until: 1609499532000 }),
+      )
+      .mockResolvedValueOnce(branchPage(["b"]));
+
+    const branches = await getActiveBranches(defaultArgs);
+
+    const secondUrl = new URL(mockFetch.mock.calls[1][0]);
+    expect(secondUrl.searchParams.get("until")).toBe("1609499532000");
+    expect(branches).toEqual(new Set(["a", "b"]));
+  });
+
+  it("should stop when a page returns no branches even if a cursor is present", async () => {
+    mockFetch
+      .mockResolvedValueOnce(branchPage(["a"], "cursor-1"))
+      .mockResolvedValueOnce(branchPage([], "cursor-2"));
+
+    const branches = await getActiveBranches(defaultArgs);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(branches).toEqual(new Set(["a"]));
+  });
+
+  it("should throw when the pagination cursor repeats instead of looping or returning a partial set", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(branchPage(["a"], "cursor-1")),
+    );
+
+    await expect(getActiveBranches(defaultArgs)).rejects.toThrow(
+      /pagination cursor repeated/,
+    );
+  });
+
+  it("should throw instead of returning a partial set when exceeding the max page bound", async () => {
+    let page = 0;
+    mockFetch.mockImplementation(() => {
+      page++;
+      return Promise.resolve(branchPage([`branch-${page}`], `cursor-${page}`));
+    });
+
+    await expect(getActiveBranches(defaultArgs)).rejects.toThrow(
+      /exceeded 100 pages/,
+    );
+  });
+
+  it("should omit teamId query param when not provided", async () => {
+    mockFetch.mockResolvedValueOnce(branchPage(["main"]));
+
+    await getActiveBranches({ projectId: "prj_123", token: "tok_abc" });
+
+    const url = new URL(mockFetch.mock.calls[0][0]);
+    expect(url.searchParams.has("teamId")).toBe(false);
+  });
+
+  it("should throw HTTPError when any page request fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce(branchPage(["a"], "cursor-1"))
+      .mockResolvedValueOnce(errorResponse(500, "Internal Server Error"));
+
+    const err = await getActiveBranches(defaultArgs).catch((e) => e);
+
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe(
+      "Failed to fetch active branches: 500 Internal Server Error",
+    );
   });
 });
 

--- a/packages/slack-bolt/src/internal/vercel/index.ts
+++ b/packages/slack-bolt/src/internal/vercel/index.ts
@@ -4,6 +4,7 @@ import type {
   AddEnvironmentVariablesResult,
   CreateProjectEnv,
   EnvironmentVariable,
+  ListBranchesResponse,
 } from "./types";
 
 export async function getProject({
@@ -174,6 +175,13 @@ export async function createDeployment({
   return { id: data.id, url: data.url };
 }
 
+/**
+ * Safety bound on pagination. Callers use the returned set to decide which
+ * Slack apps to DELETE, so a partial set must never be returned silently:
+ * if this bound is hit, we throw instead.
+ */
+const MAX_BRANCH_PAGES = 100;
+
 export async function getActiveBranches({
   projectId,
   token,
@@ -183,23 +191,56 @@ export async function getActiveBranches({
   token: string;
   teamId?: string;
 }): Promise<Set<string>> {
-  const params = new URLSearchParams({ active: "1", limit: "100" });
-  if (teamId) params.set("teamId", teamId);
+  const branches = new Set<string>();
+  const seenCursors = new Set<string>();
+  let until: string | undefined;
 
-  const response = await fetch(
-    `https://api.vercel.com/v5/projects/${encodeURIComponent(projectId)}/branches?${params}`,
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
+  for (let page = 0; page < MAX_BRANCH_PAGES; page++) {
+    const params = new URLSearchParams({ active: "1", limit: "100" });
+    if (teamId) params.set("teamId", teamId);
+    if (until) params.set("until", until);
 
-  if (!response.ok) {
-    throw await HTTPError.fromResponse(
-      "Failed to fetch active branches",
-      response,
+    const response = await fetch(
+      `https://api.vercel.com/v5/projects/${encodeURIComponent(projectId)}/branches?${params}`,
+      { headers: { Authorization: `Bearer ${token}` } },
     );
+
+    if (!response.ok) {
+      throw await HTTPError.fromResponse(
+        "Failed to fetch active branches",
+        response,
+      );
+    }
+
+    const data: ListBranchesResponse = await response.json();
+    const pageBranches = data.branches ?? [];
+    for (const b of pageBranches) {
+      branches.add(b.branch);
+    }
+
+    // The v5 branches endpoint returns a top-level `until` cursor when more
+    // pages exist; it is absent on the last page.
+    const next =
+      data.until !== undefined && data.until !== null
+        ? String(data.until)
+        : undefined;
+
+    if (!next || pageBranches.length === 0) {
+      return branches;
+    }
+
+    if (seenCursors.has(next)) {
+      throw new Error(
+        "Failed to fetch active branches: pagination cursor repeated, aborting to avoid returning a partial branch list",
+      );
+    }
+    seenCursors.add(next);
+    until = next;
   }
 
-  const data: { branches?: { branch: string }[] } = await response.json();
-  return new Set(data.branches?.map((b) => b.branch) ?? []);
+  throw new Error(
+    `Failed to fetch active branches: exceeded ${MAX_BRANCH_PAGES} pages, aborting to avoid returning a partial branch list`,
+  );
 }
 
 export async function getEnvironmentVariables({

--- a/packages/slack-bolt/src/internal/vercel/types.ts
+++ b/packages/slack-bolt/src/internal/vercel/types.ts
@@ -12,6 +12,19 @@ export type AddEnvironmentVariablesResult = {
   failed: { error: { code: string; message: string; key?: string } }[];
 };
 
+/**
+ * Response of GET /v5/projects/{idOrName}/branches.
+ *
+ * Unlike most Vercel list endpoints (which return a `pagination` object),
+ * this endpoint returns a top-level `until` cursor. When `until` is present,
+ * more pages exist and it must be passed as the `until` query parameter of
+ * the next request. When it is absent, the last page has been reached.
+ */
+export type ListBranchesResponse = {
+  branches?: { branch: string }[];
+  until?: string | number;
+};
+
 export type EnvironmentVariable = {
   id: string;
   key: string;


### PR DESCRIPTION
## Finding

**Severity: HIGH_BUG** (`other-destructive-pagination-bug`) — `packages/slack-bolt/src/cleanup.ts` + `packages/slack-bolt/src/internal/vercel/index.ts` (`getActiveBranches`).

`cleanupOrphanedApps` classifies a branch as orphaned purely via `!activeBranches.has(env.gitBranch)`. `getActiveBranches` fetched `GET /v5/projects/{id}/branches?active=1&limit=100` **without paginating**, so on projects with more than 100 active branches, live branches were silently omitted from the set, classified as orphaned, and their Slack apps DELETED and Slack env vars removed — destructive data loss.

## Fix

- `getActiveBranches` now paginates through **all** results before returning the set. The pagination contract was verified against the actual Vercel API implementation of the v5 branches endpoint: unlike most Vercel list endpoints (which return a `pagination: { count, next, prev }` object), this endpoint returns a **top-level `until` cursor** that is present only when more pages exist and must be passed back as the `until` query parameter of the next request. It is absent on the last page.
- Loop guards: because the caller uses this set to decide which Slack apps to delete, a partial set must never be returned silently. The function **throws** if the pagination cursor ever repeats or if a 100-page safety bound is exceeded.
- Added a documented `ListBranchesResponse` type in `packages/slack-bolt/src/internal/vercel/types.ts`.
- The existing behavior in `cleanup.ts` where a failed branch fetch throws and aborts cleanup is preserved (defense in depth — nothing is deleted on error).
- Changeset added (patch for `@vercel/slack-bolt`).

## Tests

Extended `packages/slack-bolt/src/internal/vercel/index.test.ts` with `getActiveBranches` coverage:
- two-page response: returned set contains branches from **both** pages, and the second request carries the cursor as `until` (plus `active=1`/`teamId` preserved)
- numeric cursor support, single-page short-circuit, empty-page stop
- repeated cursor → throws; >100 pages → throws (no partial set ever returned)
- HTTPError propagation when any page request fails

Added `packages/slack-bolt/src/cleanup.test.ts`:
- a branch only present on **page 2** of active branches is NOT treated as stale (no DELETE requests issued)
- cleanup aborts without deleting anything when the branch fetch fails

## Verification

- `pnpm --filter @vercel/slack-bolt test` — 230 tests passed (7 files)
- `pnpm --filter @vercel/slack-bolt typecheck` — clean
- `pnpm --filter @vercel/slack-bolt lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)