### PR TITLE
feat: support @slack/bolt 5.x (2.0.0)

### DIFF
--- a/.changeset/support-slack-bolt-5.md
+++ b/.changeset/support-slack-bolt-5.md
@@ -1,0 +1,15 @@
+---
+"@vercel/slack-bolt": major
+---
+
+Support `@slack/bolt` 5.x.
+
+`@vercel/slack-bolt` 2.x requires `@slack/bolt` `^5.0.0`. If you are still on `@slack/bolt` 4.x, stay on `@vercel/slack-bolt` 1.x.
+
+Breaking changes carried over from the Slack SDK upgrade:
+
+- `@slack/oauth` is bumped to 4.x and `@slack/logger` to 5.x. `@slack/oauth` 4 uses `@slack/web-api` 8, which removed `clientOptions.agent`, `clientOptions.tls`, `clientOptions.requestInterceptor`, `clientOptions.adapter`, and `clientOptions.attachOriginalToWebAPIRequestError`. If you passed any of these via `installerOptions.clientOptions`, use `installerOptions.clientOptions.fetch` to supply a custom `fetch` implementation instead (the original transport error is now always available as `error.cause` on `WebAPIRequestError`).
+- `@slack/oauth` 4 error classes now extend `SlackOAuthError`, and `error.name` reflects the concrete class name (for example `InstallerInitializationError`) rather than the generic `'Error'`. Update any code that branches on `error.name`; `instanceof` checks and `error.code` are unaffected.
+- `@slack/bolt` 5 itself removes `WorkflowStep`, replaces `axios` with `fetch`, and makes `respond()` throw a `RespondError` on non-2xx responses. See the [Bolt 5.0.0 release notes](https://github.com/slackapi/bolt-js/releases/tag/v5.0.0) for the full list.
+
+The Node.js requirement is unchanged (`>=22`).

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,7 +11,7 @@
 		"lint:fix": "biome format --write"
 	},
 	"dependencies": {
-		"@slack/bolt": "^4.7.3",
+		"@slack/bolt": "^5.1.0",
 		"@upstash/redis": "^1.38.3",
 		"@vercel/slack-bolt": "workspace:*",
 		"next": "16.3.4",

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -12,14 +12,21 @@ Visit our [template](https://vercel.com/templates/backend/slack-bolt-with-nitro)
 ## Installation
 
 ```bash
-npm install @vercel/slack-bolt
+npm install @vercel/slack-bolt @slack/bolt
 # or
-yarn add @vercel/slack-bolt
+yarn add @vercel/slack-bolt @slack/bolt
 # or
-pnpm add @vercel/slack-bolt
+pnpm add @vercel/slack-bolt @slack/bolt
 # or
-bun add @vercel/slack-bolt
+bun add @vercel/slack-bolt @slack/bolt
 ```
+
+`@slack/bolt` is a peer dependency. Pick the `@vercel/slack-bolt` major that matches your Bolt version:
+
+| `@vercel/slack-bolt` | `@slack/bolt` |
+| -------------------- | ------------- |
+| 2.x                  | 5.x           |
+| 1.x                  | 4.x           |
 
 ## API Reference
 

--- a/packages/slack-bolt/package.json
+++ b/packages/slack-bolt/package.json
@@ -62,8 +62,8 @@
   "author": "Vercel",
   "license": "MIT",
   "dependencies": {
-    "@slack/logger": "^4.0.1",
-    "@slack/oauth": "3.0.5",
+    "@slack/logger": "^5.0.0",
+    "@slack/oauth": "^4.0.0",
     "@vercel/functions": "^3.9.5",
     "commander": "^14.0.3",
     "yaml": "^2.9.0",
@@ -80,7 +80,7 @@
     "vitest": "5.0.0"
   },
   "peerDependencies": {
-    "@slack/bolt": "^4.4.0"
+    "@slack/bolt": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@slack/bolt": {

--- a/packages/slack-bolt/src/oauth-adapters.test.ts
+++ b/packages/slack-bolt/src/oauth-adapters.test.ts
@@ -1,3 +1,4 @@
+import { type Logger, LogLevel } from "@slack/logger";
 import { InstallProvider } from "@slack/oauth";
 import { describe, expect, it } from "vitest";
 import { createResponseCapture, toIncomingMessage } from "./oauth-adapters";
@@ -241,5 +242,117 @@ describe("InstallProvider integration", () => {
     expect(location).toContain("https://slack.com/oauth/v2/authorize");
     expect(location).toContain("client_id=test-client-id");
     expect(location).toContain("scope=chat%3Awrite");
+  });
+
+  it("handleCallback completes the OAuth flow via adapters", async () => {
+    const fetch = async (url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("oauth.v2.access")) {
+        return Response.json({
+          ok: true,
+          app_id: "A1",
+          authed_user: { id: "U1" },
+          scope: "chat:write",
+          token_type: "bot",
+          access_token: "xoxb-1",
+          bot_user_id: "UB",
+          team: { id: "T1", name: "t" },
+          enterprise: null,
+          is_enterprise_install: false,
+        });
+      }
+      if (u.includes("auth.test")) {
+        return Response.json({
+          ok: true,
+          bot_id: "B1",
+          url: "https://t.slack.com/",
+          user_id: "UB",
+          team_id: "T1",
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    };
+    const silentLogger: Logger = {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+      setLevel() {},
+      getLevel: () => LogLevel.ERROR,
+      setName() {},
+    };
+    const stored: unknown[] = [];
+    const installer = new InstallProvider({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      stateSecret: "test-state-secret",
+      directInstall: true,
+      logger: silentLogger,
+      clientOptions: { fetch },
+      installationStore: {
+        storeInstallation: async (installation) => {
+          stored.push(installation);
+        },
+        fetchInstallation: async () => {
+          throw new Error("not implemented");
+        },
+      },
+    });
+    const installOptions = {
+      scopes: ["chat:write"],
+      redirectUri: "https://example.com/slack/oauth_redirect",
+    };
+
+    const install = createResponseCapture();
+    await installer.handleInstallPath(
+      toIncomingMessage(
+        new Request("https://example.com/slack/install", {
+          headers: { Host: "example.com" },
+        }),
+      ),
+      install,
+      {},
+      installOptions,
+    );
+    const installResponse = install.toResponse();
+    expect(installResponse.status).toBe(302);
+    const state = new URL(
+      installResponse.headers.get("location")!,
+    ).searchParams.get("state")!;
+    expect(state).toBeTruthy();
+    const cookie = installResponse.headers.get("set-cookie")!.split(";")[0];
+    expect(cookie).toMatch(/^slack-app-oauth-state=/);
+
+    const callback = createResponseCapture();
+    await installer.handleCallback(
+      toIncomingMessage(
+        new Request(
+          `https://example.com/slack/oauth_redirect?code=abc&state=${encodeURIComponent(state)}`,
+          { headers: { Host: "example.com", Cookie: cookie } },
+        ),
+      ),
+      callback,
+      {},
+    );
+    const callbackResponse = callback.toResponse();
+    expect(callbackResponse.status).toBe(200);
+    expect(callbackResponse.headers.get("content-type")).toContain("text/html");
+    expect(callbackResponse.headers.get("set-cookie")).toContain(
+      "slack-app-oauth-state=deleted",
+    );
+    expect(stored).toHaveLength(1);
+
+    const mismatch = createResponseCapture();
+    await installer.handleCallback(
+      toIncomingMessage(
+        new Request(
+          "https://example.com/slack/oauth_redirect?code=abc&state=wrong",
+          { headers: { Host: "example.com", Cookie: cookie } },
+        ),
+      ),
+      mismatch,
+      {},
+    );
+    expect(mismatch.toResponse().status).toBe(400);
   });
 });

--- a/packages/slack-bolt/src/oauth-adapters.ts
+++ b/packages/slack-bolt/src/oauth-adapters.ts
@@ -6,8 +6,8 @@
  * Do not reuse for other Node libraries without verifying which methods
  * they call.
  *
- * Targets @slack/oauth\@3.0.5 InstallProvider internals.
- * Do not upgrade without running the integration tests.
+ * Targets @slack/oauth 4.x InstallProvider internals.
+ * Do not upgrade to a new major without running the integration tests.
  */
 
 import { IncomingMessage, ServerResponse } from "node:http";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   examples/nextjs:
     dependencies:
       '@slack/bolt':
-        specifier: ^4.7.3
-        version: 4.7.3(@types/express@5.0.3)
+        specifier: ^5.1.0
+        version: 5.1.0(@types/express@5.0.3)(undici@7.29.1)
       '@upstash/redis':
         specifier: ^1.38.3
         version: 1.38.3
@@ -82,14 +82,14 @@ importers:
   packages/slack-bolt:
     dependencies:
       '@slack/bolt':
-        specifier: ^4.4.0
-        version: 4.7.3(@types/express@5.0.3)
+        specifier: ^5.0.0
+        version: 5.1.0(@types/express@5.0.3)(undici@7.29.1)
       '@slack/logger':
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^5.0.0
+        version: 5.0.0
       '@slack/oauth':
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: ^4.0.0
+        version: 4.0.0
       '@vercel/functions':
         specifier: ^3.9.5
         version: 3.9.5(ws@8.21.3)
@@ -936,9 +936,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@slack/bolt@4.7.3':
-    resolution: {integrity: sha512-bODs8q/yNDWUPoxmQhFrRqLMA5vhB/PDizYWqb6CkQhLWEUo5JFtfJcmeU4ElGl6qSt++OKjSYNa4MPc77CleQ==}
-    engines: {node: '>=18', npm: '>=8.6.0'}
+  '@slack/bolt@5.1.0':
+    resolution: {integrity: sha512-lSQzEs/OMDVIbTVb+ZXZa7zsYGvnB1d58CnK55vdYdVeSmHMON1RjSgPf3lGUE9lYhNTUIjbFCrCrsJ1j5SAUA==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
     peerDependencies:
       '@types/express': ^5.0.0
 
@@ -947,25 +947,27 @@ packages:
     engines: {node: '>= 20', npm: '>=9.6.4'}
     hasBin: true
 
-  '@slack/logger@4.0.1':
-    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
+  '@slack/logger@5.0.0':
+    resolution: {integrity: sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
-  '@slack/oauth@3.0.5':
-    resolution: {integrity: sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==}
-    engines: {node: '>=18', npm: '>=8.6.0'}
+  '@slack/oauth@4.0.0':
+    resolution: {integrity: sha512-Aqs5bGghT+VtNcdwVOQy7CcyCfDNd9YYnZsCRukIF9p1Mxuq4uL+BjqlWQB0SeS4wzrLzePPgvj8JDuQil+ezA==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
 
-  '@slack/socket-mode@2.0.7':
-    resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
+  '@slack/socket-mode@3.0.1':
+    resolution: {integrity: sha512-7L4adgnJtQvQgo5cfIwqHG1QuR8mdZQ/WdMScNDp6uK644ZqnHDAa4rR+vZYfZFdJ5+obCqZQ66Dad8kcwJ4Jg==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
+    peerDependencies:
+      undici: ^7.0.0
 
-  '@slack/types@2.22.0':
-    resolution: {integrity: sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==}
-    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+  '@slack/types@3.1.0':
+    resolution: {integrity: sha512-bTzqrO3lxJ5iWedo1eJKNAs1koyEhaTwKLJUkD3KETnPeQvD978AAE4jvWstUws8Gbbc4JR6iYE6F7XjE8UGmw==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
-  '@slack/web-api@7.19.0':
-    resolution: {integrity: sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
+  '@slack/web-api@8.1.1':
+    resolution: {integrity: sha512-am/z/LLbEC7gNQp6FpaGT0l4XnWqcXetpwdgZHzS7Nbb96q9R9QwWA3lo0ZXGuAHDkct0MvFnouzuc2Y4XNmow==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -1148,14 +1150,14 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1473,10 +1475,6 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1520,12 +1518,6 @@ packages:
 
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
-
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.19.0:
-    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   baseline-browser-mapping@2.11.19:
     resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
@@ -1610,10 +1602,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -1660,10 +1648,6 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1739,10 +1723,6 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.2:
@@ -1821,19 +1801,6 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  form-data@4.0.6:
-    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
-    engines: {node: '>= 6'}
-
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1901,10 +1868,6 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -1918,10 +1881,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -1954,9 +1913,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  is-electron@2.2.2:
-    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2246,16 +2202,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -2445,10 +2393,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -2785,6 +2729,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -3608,78 +3556,59 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@slack/bolt@4.7.3(@types/express@5.0.3)':
+  '@slack/bolt@5.1.0(@types/express@5.0.3)(undici@7.29.1)':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/oauth': 3.0.5
-      '@slack/socket-mode': 2.0.7
-      '@slack/types': 2.22.0
-      '@slack/web-api': 7.19.0
+      '@slack/logger': 5.0.0
+      '@slack/oauth': 4.0.0
+      '@slack/socket-mode': 3.0.1(undici@7.29.1)
+      '@slack/types': 3.1.0
+      '@slack/web-api': 8.1.1
       '@types/express': 5.0.3
-      axios: 1.19.0
       express: 5.2.1
       path-to-regexp: 8.4.2
       raw-body: 3.0.2
       tsscmp: 1.0.6
     transitivePeerDependencies:
-      - bufferutil
-      - debug
       - supports-color
-      - utf-8-validate
+      - undici
 
   '@slack/cli-hooks@2.0.0':
     dependencies:
       minimist: 1.2.8
       semver: 7.8.5
 
-  '@slack/logger@4.0.1':
+  '@slack/logger@5.0.0':
     dependencies:
       '@types/node': 26.4.1
 
-  '@slack/oauth@3.0.5':
+  '@slack/oauth@4.0.0':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/web-api': 7.19.0
+      '@slack/logger': 5.0.0
+      '@slack/web-api': 8.1.1
       '@types/jsonwebtoken': 9.0.10
       '@types/node': 26.4.1
       jsonwebtoken: 9.0.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
-  '@slack/socket-mode@2.0.7':
+  '@slack/socket-mode@3.0.1(undici@7.29.1)':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/web-api': 7.19.0
+      '@slack/logger': 5.0.0
+      '@slack/web-api': 8.1.1
       '@types/node': 26.4.1
-      '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.21.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
+      undici: 7.29.1
 
-  '@slack/types@2.22.0': {}
+  '@slack/types@3.1.0': {}
 
-  '@slack/web-api@7.19.0':
+  '@slack/web-api@8.1.1':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/types': 2.22.0
+      '@slack/logger': 5.0.0
+      '@slack/types': 3.1.0
       '@types/node': 26.4.1
-      '@types/retry': 0.12.0
-      axios: 1.19.0
+      '@types/retry': 0.12.5
       eventemitter3: 5.0.4
-      form-data: 4.0.6
-      is-electron: 2.2.2
-      is-stream: 2.0.1
       p-queue: 6.6.2
       p-retry: 4.6.2
       retry: 0.13.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -3837,6 +3766,8 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/retry@0.12.5': {}
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 26.4.1
@@ -3844,10 +3775,6 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 26.4.1
-
-  '@types/ws@8.18.1':
-    dependencies:
       '@types/node': 26.4.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -4043,12 +3970,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -4082,18 +4003,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
-
-  asynckit@0.4.0: {}
-
-  axios@1.19.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   baseline-browser-mapping@2.11.19: {}
 
@@ -4181,10 +4090,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@10.0.1: {}
 
   commander@14.0.3: {}
@@ -4212,8 +4117,6 @@ snapshots:
       ms: 2.1.3
 
   defu@6.1.7: {}
-
-  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -4268,13 +4171,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -4409,16 +4305,6 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  follow-redirects@1.16.0: {}
-
-  form-data@4.0.6:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -4487,10 +4373,6 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -4506,13 +4388,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   human-id@4.2.0: {}
 
@@ -4531,8 +4406,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
-
-  is-electron@2.2.2: {}
 
   is-extglob@2.1.1: {}
 
@@ -4761,13 +4634,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime-db@1.52.0: {}
-
   mime-db@1.54.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -4929,8 +4796,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   qs@6.15.3:
     dependencies:
@@ -5320,6 +5185,8 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@7.29.1: {}
+
   unicode-emoji-modifier-base@1.0.0: {}
 
   universalify@0.1.2: {}
@@ -5394,7 +5261,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.3: {}
+  ws@8.21.3:
+    optional: true
 
   xdg-app-paths@5.5.1:
     dependencies:


### PR DESCRIPTION
Closes #214

## Summary

- Peer range `@slack/bolt` → `^5.0.0`; `@slack/oauth` → `^4.0.0`; `@slack/logger` → `^5.0.0`.
- Released as **2.0.0** to mirror the Bolt major. Bolt 4.x users stay on `@vercel/slack-bolt` 1.x (documented in the README with a compatibility table, and in the changeset).
- Next.js example bumped to `@slack/bolt@^5.1.0`.
- New integration test drives the real `InstallProvider` (oauth 4.x) through `handleInstallPath` → `handleCallback` via the Web↔Node adapters with a stubbed `clientOptions.fetch`, covering state cookie round-trip, `storeInstallation`, and a state-mismatch 400. This is the coupling point `oauth-adapters.ts` warns about and it previously had no `handleCallback` coverage.

## Why a major

`@slack/oauth` 4 pulls in `@slack/web-api` 8, and `VercelInstallerOptions.clientOptions` is typed as `InstallProviderOptions["clientOptions"]`, so the removal of `clientOptions.agent` / `.tls` / `.requestInterceptor` / `.adapter` / `.attachOriginalToWebAPIRequestError` leaks through to our public types (use `clientOptions.fetch` instead). `@slack/oauth` 4 also changes `error.name` from `'Error'` to the concrete class name. Both are called out in the changeset.

## Verification

Bolt 5.1.0 / oauth 4.0.0 / logger 5.0.0 resolved in the lockfile; `axios`, `@slack/web-api@7`, `@slack/oauth@3`, `@slack/logger@4` no longer appear anywhere in `pnpm-lock.yaml`.

- `pnpm install --frozen-lockfile` ✅
- `packages/slack-bolt`: `test` 234/234 ✅ · `typecheck` ✅ · `build` ✅ · `lint` ✅ · `attw` ✅ (all resolutions, `.` and `./preview`)
- `examples/nextjs`: `tsc --noEmit` ✅ · `lint` ✅

Not done: a live OAuth install against Slack on the deployed example. Worth a quick smoke test before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)