### PR TITLE
feat: support @slack/bolt 5.x

### DIFF
--- a/.changeset/wide-moons-tap.md
+++ b/.changeset/wide-moons-tap.md
@@ -1,0 +1,5 @@
+---
+"@vercel/slack-bolt": minor
+---
+
+Widen the `@slack/bolt` peer dependency range to allow 5.x.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,12 @@ env:
 
 jobs:
   ci:
-    name: Node.js ${{ matrix.node-version }}
+    name: Node.js ${{ matrix.node-version }} / Bolt ${{ matrix.slack-bolt }}.x
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [22, 24, 26]
+        slack-bolt: ['4', '5']
       fail-fast: false
     steps:
       - name: Checkout
@@ -53,6 +54,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Pin @slack/bolt ${{ matrix.slack-bolt }}.x
+        run: |
+          pnpm --filter @vercel/slack-bolt add -D "@slack/bolt@^${{ matrix.slack-bolt }}"
+          pnpm --filter slack-bolt-with-next add "@slack/bolt@^${{ matrix.slack-bolt }}"
 
       - name: Setup example env
         run: cp examples/nextjs/.env.example examples/nextjs/.env.local

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,7 +11,7 @@
 		"lint:fix": "biome format --write"
 	},
 	"dependencies": {
-		"@slack/bolt": "^4.7.3",
+		"@slack/bolt": "^5.1.0",
 		"@upstash/redis": "^1.38.3",
 		"@vercel/slack-bolt": "workspace:*",
 		"next": "16.3.4",

--- a/packages/slack-bolt/package.json
+++ b/packages/slack-bolt/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
     "@biomejs/biome": "catalog:",
+    "@slack/bolt": "^5.1.0",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "5.0.0",
     "tsdown": "^0.22.14",
@@ -80,7 +81,7 @@
     "vitest": "5.0.0"
   },
   "peerDependencies": {
-    "@slack/bolt": "^4.4.0"
+    "@slack/bolt": "^4.4.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@slack/bolt": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   examples/nextjs:
     dependencies:
       '@slack/bolt':
-        specifier: ^4.7.3
-        version: 4.7.3(@types/express@5.0.3)
+        specifier: ^5.1.0
+        version: 5.1.0(@types/express@5.0.3)(undici@7.29.1)
       '@upstash/redis':
         specifier: ^1.38.3
         version: 1.38.3
@@ -81,9 +81,6 @@ importers:
 
   packages/slack-bolt:
     dependencies:
-      '@slack/bolt':
-        specifier: ^4.4.0
-        version: 4.7.3(@types/express@5.0.3)
       '@slack/logger':
         specifier: ^4.0.1
         version: 4.0.1
@@ -109,6 +106,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 2.5.12
+      '@slack/bolt':
+        specifier: ^5.1.0
+        version: 5.1.0(@types/express@5.0.3)(undici@7.29.1)
       '@types/node':
         specifier: 'catalog:'
         version: 26.4.1
@@ -936,9 +936,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@slack/bolt@4.7.3':
-    resolution: {integrity: sha512-bODs8q/yNDWUPoxmQhFrRqLMA5vhB/PDizYWqb6CkQhLWEUo5JFtfJcmeU4ElGl6qSt++OKjSYNa4MPc77CleQ==}
-    engines: {node: '>=18', npm: '>=8.6.0'}
+  '@slack/bolt@5.1.0':
+    resolution: {integrity: sha512-lSQzEs/OMDVIbTVb+ZXZa7zsYGvnB1d58CnK55vdYdVeSmHMON1RjSgPf3lGUE9lYhNTUIjbFCrCrsJ1j5SAUA==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
     peerDependencies:
       '@types/express': ^5.0.0
 
@@ -951,21 +951,39 @@ packages:
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
+  '@slack/logger@5.0.0':
+    resolution: {integrity: sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/oauth@3.0.5':
     resolution: {integrity: sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==}
     engines: {node: '>=18', npm: '>=8.6.0'}
 
-  '@slack/socket-mode@2.0.7':
-    resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
+  '@slack/oauth@4.0.0':
+    resolution: {integrity: sha512-Aqs5bGghT+VtNcdwVOQy7CcyCfDNd9YYnZsCRukIF9p1Mxuq4uL+BjqlWQB0SeS4wzrLzePPgvj8JDuQil+ezA==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
+
+  '@slack/socket-mode@3.0.1':
+    resolution: {integrity: sha512-7L4adgnJtQvQgo5cfIwqHG1QuR8mdZQ/WdMScNDp6uK644ZqnHDAa4rR+vZYfZFdJ5+obCqZQ66Dad8kcwJ4Jg==}
+    engines: {node: '>=20', npm: '>=9.6.4'}
+    peerDependencies:
+      undici: ^7.0.0
 
   '@slack/types@2.22.0':
     resolution: {integrity: sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
+  '@slack/types@3.1.0':
+    resolution: {integrity: sha512-bTzqrO3lxJ5iWedo1eJKNAs1koyEhaTwKLJUkD3KETnPeQvD978AAE4jvWstUws8Gbbc4JR6iYE6F7XjE8UGmw==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/web-api@7.19.0':
     resolution: {integrity: sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/web-api@8.1.1':
+    resolution: {integrity: sha512-am/z/LLbEC7gNQp6FpaGT0l4XnWqcXetpwdgZHzS7Nbb96q9R9QwWA3lo0ZXGuAHDkct0MvFnouzuc2Y4XNmow==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -1148,14 +1166,14 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -2786,6 +2804,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
+
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
@@ -3608,24 +3630,21 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@slack/bolt@4.7.3(@types/express@5.0.3)':
+  '@slack/bolt@5.1.0(@types/express@5.0.3)(undici@7.29.1)':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/oauth': 3.0.5
-      '@slack/socket-mode': 2.0.7
-      '@slack/types': 2.22.0
-      '@slack/web-api': 7.19.0
+      '@slack/logger': 5.0.0
+      '@slack/oauth': 4.0.0
+      '@slack/socket-mode': 3.0.1(undici@7.29.1)
+      '@slack/types': 3.1.0
+      '@slack/web-api': 8.1.1
       '@types/express': 5.0.3
-      axios: 1.19.0
       express: 5.2.1
       path-to-regexp: 8.4.2
       raw-body: 3.0.2
       tsscmp: 1.0.6
     transitivePeerDependencies:
-      - bufferutil
-      - debug
       - supports-color
-      - utf-8-validate
+      - undici
 
   '@slack/cli-hooks@2.0.0':
     dependencies:
@@ -3633,6 +3652,10 @@ snapshots:
       semver: 7.8.5
 
   '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 26.4.1
+
+  '@slack/logger@5.0.0':
     dependencies:
       '@types/node': 26.4.1
 
@@ -3647,21 +3670,25 @@ snapshots:
       - debug
       - supports-color
 
-  '@slack/socket-mode@2.0.7':
+  '@slack/oauth@4.0.0':
     dependencies:
-      '@slack/logger': 4.0.1
-      '@slack/web-api': 7.19.0
+      '@slack/logger': 5.0.0
+      '@slack/web-api': 8.1.1
+      '@types/jsonwebtoken': 9.0.10
       '@types/node': 26.4.1
-      '@types/ws': 8.18.1
+      jsonwebtoken: 9.0.3
+
+  '@slack/socket-mode@3.0.1(undici@7.29.1)':
+    dependencies:
+      '@slack/logger': 5.0.0
+      '@slack/web-api': 8.1.1
+      '@types/node': 26.4.1
       eventemitter3: 5.0.4
-      ws: 8.21.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
+      undici: 7.29.1
 
   '@slack/types@2.22.0': {}
+
+  '@slack/types@3.1.0': {}
 
   '@slack/web-api@7.19.0':
     dependencies:
@@ -3680,6 +3707,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  '@slack/web-api@8.1.1':
+    dependencies:
+      '@slack/logger': 5.0.0
+      '@slack/types': 3.1.0
+      '@types/node': 26.4.1
+      '@types/retry': 0.12.5
+      eventemitter3: 5.0.4
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -3837,6 +3875,8 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/retry@0.12.5': {}
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 26.4.1
@@ -3844,10 +3884,6 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 26.4.1
-
-  '@types/ws@8.18.1':
-    dependencies:
       '@types/node': 26.4.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -5320,6 +5356,8 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@7.29.1: {}
+
   unicode-emoji-modifier-base@1.0.0: {}
 
   universalify@0.1.2: {}
@@ -5394,7 +5432,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.3: {}
+  ws@8.21.3:
+    optional: true
 
   xdg-app-paths@5.5.1:
     dependencies:


### PR DESCRIPTION
Widens the peer range to ^4.4.0 || ^5.0.0. No source changes were needed. The three symbols the receiver uses at runtime (verifySlackRequest, ReceiverAuthenticityError and ReceiverMultipleAckError) are unchanged in 5.x, and bolt 5 still accepts the receiver's InstallProvider for the OAuth path.

The package also needs an explicit @slack/bolt devDependency. Without one, pnpm auto-installs its own copy for the workspace, so the receiver ends up typed against a different bolt than the example and typecheck fails with "Type 'VercelReceiver' is not assignable to type 'Receiver'".

CI gets a slack-bolt matrix dimension so both declared majors get tested, not just whichever one the lockfile happens to hold.

Closes #214 
