### PR TITLE
docs: document Bolt 5 compatibility and upgrade notes

### DIFF
--- a/.changeset/wide-moons-tap.md
+++ b/.changeset/wide-moons-tap.md
@@ -2,4 +2,16 @@
 "@vercel/slack-bolt": minor
 ---
 
-Widen the `@slack/bolt` peer dependency range to allow 5.x.
+Support `@slack/bolt` 5.x by widening the peer dependency range to `^4.4.0 || ^5.0.0`.
+
+No source changes were needed. The receiver only depends on Bolt symbols that are unchanged in 5.x (`verifySlackRequest`, `ReceiverAuthenticityError`, `ReceiverMultipleAckError` and the `Receiver` interface), and Bolt 5 continues to consume the receiver's OAuth `installer` the same way. CI now runs the full suite against both Bolt 4 and Bolt 5.
+
+Things to know when upgrading to Bolt 5:
+
+- If you previously forced Bolt 5 with `--legacy-peer-deps`, remove it. That flag also skips `@slack/socket-mode`'s `undici` peer, which makes `require('@slack/bolt')` fail with `Cannot find module 'undici'`.
+- If you do not list `@slack/bolt` in your own `package.json` and rely on peer auto-install, pin it explicitly. The widened range means a fresh install now resolves to Bolt 5.
+- The OAuth installer still uses `@slack/oauth` 3.x internally (Bolt 5 ships 4.x), so Bolt 5 apps carry both. This is harmless: the shared `Installation`, `InstallationStore` and `Logger` types are structurally identical across the two versions. Two consequences:
+  - `installerOptions.clientOptions` follows `@slack/web-api` 7's `WebClientOptions` (`agent`, `tls`), not 8's (`fetch`). A custom `fetch` passed to the Bolt `App` is not applied to the OAuth token exchange.
+  - Errors passed to `installerOptions.callbackOptions.failure` are `@slack/oauth` 3.x instances. Check `error.code` rather than using `instanceof` against classes imported from `@slack/oauth`.
+
+Moving the installer to `@slack/oauth` 4.x is planned for the next major, when Bolt 4 support is dropped.

--- a/packages/slack-bolt/README.md
+++ b/packages/slack-bolt/README.md
@@ -21,6 +21,15 @@ pnpm add @vercel/slack-bolt
 bun add @vercel/slack-bolt
 ```
 
+### Compatibility
+
+| Dependency    | Supported versions  |
+| ------------- | ------------------- |
+| `@slack/bolt` | `^4.4.0` or `^5.0.0` |
+| Node.js       | `>=22`              |
+
+`@slack/bolt` is a peer dependency, so declare it in your own `package.json` alongside this package. Do not install with `--legacy-peer-deps`: Bolt 5's `@slack/socket-mode` declares `undici` as a peer, and skipping peers makes `require('@slack/bolt')` fail with `Cannot find module 'undici'`.
+
 ## API Reference
 
 ### `VercelReceiver`
@@ -160,6 +169,15 @@ export const GET = receiver.handleCallback;
 An `installationStore` is required in serverless environments. The default in-memory store does not survive cold starts, so each new function invocation would lose all installation data.
 
 Your store must implement `storeInstallation`, `fetchInstallation`, and optionally `deleteInstallation`. Any persistent backend works (Redis, PostgreSQL, DynamoDB, etc). See the [Bolt InstallationStore docs](https://slack.dev/bolt-js/concepts/authenticating-oauth#the-installation-store) for the full interface, and the [Next.js example](https://github.com/vercel-labs/slack-bolt/tree/examples/examples/nextjs) for a working Redis implementation.
+
+### Notes for Bolt 5
+
+The receiver's OAuth installer uses `@slack/oauth` 3.x internally, while Bolt 5 depends on `@slack/oauth` 4.x. Both are installed in a Bolt 5 app. This is safe: the `Installation`, `InstallationStore` and `Logger` types you write against are structurally identical in both versions, so an `installationStore` typed via `@slack/bolt` works unchanged. Two details differ:
+
+- `installerOptions.clientOptions` follows `@slack/web-api` 7's `WebClientOptions` (`agent`, `tls`), not 8's (`fetch`). A custom `fetch` you pass to the Bolt `App` is not used for the OAuth token exchange.
+- Errors passed to `installerOptions.callbackOptions.failure` are `@slack/oauth` 3.x instances. Check `error.code` rather than `instanceof` against classes imported from `@slack/oauth`, which would resolve to the 4.x copy.
+
+The installer will move to `@slack/oauth` 4.x in the next major release, when Bolt 4 support is dropped.
 
 ### `preview`
 

--- a/packages/slack-bolt/src/oauth-adapters.ts
+++ b/packages/slack-bolt/src/oauth-adapters.ts
@@ -8,6 +8,12 @@
  *
  * Targets @slack/oauth\@3.0.5 InstallProvider internals.
  * Do not upgrade without running the integration tests.
+ *
+ * Bolt 5 consumers also have @slack/oauth\@4 in their tree (Bolt's own copy).
+ * That is fine: Bolt only reads `receiver.installer.authorize` as a plain
+ * function, and the Installation/InstallationStore types are structurally
+ * identical across 3.x and 4.x. The 3.0.5 pin is deliberate until Bolt 4
+ * support is dropped, so Bolt 4 consumers keep a single copy.
  */
 
 import { IncomingMessage, ServerResponse } from "node:http";


### PR DESCRIPTION
Follow-up to #216 (closes the loop on #214). Expands the pending 1.7.0 changeset and README with what Bolt 5 adopters need to know. No code changes; the only `src/` touch is a header comment.

## What's in here

- **`.changeset/wide-moons-tap.md`** — full release note for 1.7.0: why no code changed (the receiver only uses Bolt symbols unchanged in 5.x), and three upgrade notes:
  - remove `--legacy-peer-deps` (it skips `@slack/socket-mode`'s `undici` peer → `Cannot find module 'undici'`)
  - declare `@slack/bolt` explicitly if you relied on peer auto-install (the widened range now resolves to 5.x)
  - the installer still uses `@slack/oauth` 3.x, so `installerOptions.clientOptions` follows web-api 7's shape (no `fetch`) and `callbackOptions.failure` errors should be checked via `error.code`, not `instanceof`
- **README** — a Compatibility table under Installation (`@slack/bolt` `^4.4.0 || ^5.0.0`, Node `>=22`) and a "Notes for Bolt 5" subsection under OAuth covering the two points above.
- **`oauth-adapters.ts`** — header comment recording why the `@slack/oauth@3.0.5` pin coexists safely with Bolt 5's oauth 4 and why it's deliberate until Bolt 4 support is dropped.

## Verification

- `Installation`/`InstallationStore`/`StateStore` etc. are byte-identical between `@slack/oauth` 3.0.5 and 4.0.0 (`.d.ts` diff is limited to `errors.d.ts`); `@slack/logger` 4→5 is a no-diff.
- `WebClientOptions` diff web-api 7 vs 8: 7 has `agent`/`tls`/`adapter`/`requestInterceptor`; 8 drops those and adds `fetch`.
- lint / typecheck / 233 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)