### PR TITLE
ci: version canary from pending changesets and align with OIDC publishing

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -10,9 +10,12 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
+# Publishes via npm trusted publishing (OIDC), the same mechanism as release.yml.
+# npm binds a trusted publisher to a workflow filename + environment, so this
+# workflow needs its own entry on npmjs.com: workflow `canary.yml`, environment `canary`.
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 
 jobs:
   canary:
@@ -37,16 +40,31 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm exec turbo run build --filter=@vercel/slack-bolt
+      # Apply pending changesets so the canary carries the version the next
+      # release will have (e.g. 1.7.0-canary.*) rather than the last published
+      # one. With `commit: true` in .changeset/config.json this creates a local
+      # commit, so git needs an identity. Nothing is pushed.
+      - name: Apply pending changesets
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          pnpm exec changeset version
 
+      # Use github.sha, not `git rev-parse HEAD`: the step above may have
+      # created a local commit, and the canary should name the pushed commit.
       - name: Set canary version
         working-directory: packages/slack-bolt
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          npm version "${CURRENT_VERSION}-canary.${TIMESTAMP}.${SHORT_SHA}" --no-git-tag-version
+          NEXT_VERSION=$(node -p "require('./package.json').version")
+          npm version "${NEXT_VERSION}-canary.${TIMESTAMP}.${SHORT_SHA}" --no-git-tag-version
+          echo "Publishing @vercel/slack-bolt@$(node -p "require('./package.json').version")" >> "$GITHUB_STEP_SUMMARY"
+
+      # Build after versioning: tsdown inlines package.json's version into
+      # dist/cli.js for `vercel-slack --version`.
+      - name: Build
+        run: pnpm exec turbo run build --filter=@vercel/slack-bolt
 
       - name: Publish canary
         working-directory: packages/slack-bolt


### PR DESCRIPTION
Makes the manual **Canary Release** workflow produce a canary of the *next* version and publish it the same way `release.yml` does.

## Changes

- **Version from pending changesets.** Runs `pnpm exec changeset version` before `npm version`, so a canary cut from master today is `1.7.0-canary.<timestamp>.<sha>` rather than `1.6.5-canary.*`. The repo's changeset config has `commit: true`, so the step sets a git identity for the local `RELEASING:` commit it creates (nothing is pushed). With no pending changesets it's a no-op and the canary falls back to the current version, as before.
- **Sha from `github.sha`**, not `git rev-parse HEAD` — HEAD would be the throwaway changeset commit.
- **Build after versioning.** tsdown inlines `package.json`'s version into `dist/cli.js` for `vercel-slack --version`; the previous order shipped the stale version in the canary tarball.
- **Publishing:** no mechanical change — the workflow already had `id-token: write`, `registry-url`, and no `NODE_AUTH_TOKEN`, i.e. trusted publishing, matching `release.yml`. Added a comment documenting the npm-side binding (see below).

## ⚠️ One manual step before the first run

npm trusted publishers are bound to a **workflow filename + environment**, and the existing entry is for `release.yml` / `release`. 1.6.4 and 1.6.5 carry provenance attestations (OIDC working); the last canary (March) does not, so `canary.yml` has never published via OIDC. On npmjs.com → `@vercel/slack-bolt` → Settings → Trusted Publisher, add a second GitHub Actions publisher: org `vercel-labs`, repo `slack-bolt`, workflow `canary.yml`, environment `canary`. npm allows up to 10 per package.

## Verified

Dry-run of the exact step sequence in a clean clone of this branch:

```
before: 1.6.5
🦋  All files have been updated and committed. You're ready to publish!
v1.7.0-canary.20260909144912.9636635
dist/cli.js version: "1.7.0-canary.20260909144912.9636635"
npm notice version: 1.7.0-canary.20260909144912.9636635   (23 files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)